### PR TITLE
Fixed union with 'Union' type from 'typing' to support python<3.10

### DIFF
--- a/environment.yaml
+++ b/environment.yaml
@@ -2,13 +2,13 @@ name: mol-view-spec-dev
 channels:
   - https://conda.anaconda.org/conda-forge
 dependencies:
-  - python >=3.10
+  - python >=3.9
   - pip
   - fastapi==0.93.0
   - uvicorn==0.21.0
   - requests
   - types-requests
-  - pydantic
+  - pydantic==1.10.13
 
   - nodejs >=18
 

--- a/molviewspec/app/api/examples.py
+++ b/molviewspec/app/api/examples.py
@@ -1,5 +1,5 @@
 import math
-from typing import Literal, TypeAlias
+from typing import Literal, TypeAlias, Union
 
 import requests
 from fastapi import APIRouter
@@ -1147,7 +1147,7 @@ BASE_COLOR = "#CCCCCC"  # should be #787878 but that's too dark because of missi
 
 @router.get("/portfolio/entry")
 async def portfolio_entry_or_assembly(
-    coloring: Literal["by_chain", "by_entity"] = "by_chain", assembly_id: str | None = None
+    coloring: Literal["by_chain", "by_entity"] = "by_chain", assembly_id: Union[str, None] = None
 ) -> MVSResponse:
     """
     Entry or assembly structure colored by chain, as created by PDBImages.

--- a/molviewspec/molviewspec/nodes.py
+++ b/molviewspec/molviewspec/nodes.py
@@ -315,7 +315,7 @@ class _DataFromSourceParams(BaseModel):
 
 
 class ComponentInlineParams(BaseModel):
-    selector: ComponentSelectorT | ComponentExpression | list[ComponentExpression] = Field(
+    selector: Union[ComponentSelectorT, ComponentExpression, list[ComponentExpression]] = Field(
         description="Describes one or more selections or one of the enumerated selectors."
     )
 

--- a/molviewspec/setup.py
+++ b/molviewspec/setup.py
@@ -35,7 +35,7 @@ setup(
         "scene building",
         "Mol*",
     ],
-    install_requires=["pydantic"],
+    install_requires=["pydantic<2"],
     classifiers=[
         "Development Status :: 3 - Alpha",
         # "Development Status :: 4 - Beta",


### PR DESCRIPTION
I have a project built with `python 3.9`, and initially `molviewspec` was not working. I found that the `nodes.py` module was using `|` notation to type hint unions, and this does not work on python versions prior to 3.10. Thankfully, the typing module includes a `Union` class to represent such types, and this works also on older versions of python.

Without this change, molviewspec simply does not work on older versions of python than 3.10