### PR TITLE
add _Base.additional_properties

### DIFF
--- a/molviewspec/molviewspec/builder.py
+++ b/molviewspec/molviewspec/builder.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 import math
 import os
-from typing import Sequence
+from typing import Sequence, Self
 
 from pydantic import BaseModel, PrivateAttr
 
@@ -81,6 +81,18 @@ class _Base(BaseModel):
         if self._node.children is None:
             self._node.children = []
         self._node.children.append(node)
+
+    def additional_properties(self, **kwargs) -> Self:
+        """
+        Adds provided key-value pairs as additional properties to this node.
+        key=None to remove a property.
+        """
+        properties = {
+            **(self._node.additional_properties or {}),
+            **{k: v for k, v in kwargs.items() if v is not None},
+        }
+        self._node = self._node.copy(update={"additional_properties": properties or None})
+        return self
 
 
 class Root(_Base):


### PR DESCRIPTION
@JonStargaryen I've added an easier way to set additional properties which doesn't require supporting it in every single builder function, where you can do something like:

```py
builder.download(url=_url_for_mmcif(id))
        .parse(format="mmcif")
        .model_structure()
        .additional_properties(prop="test")  # sets prop of the parent model to "test"
        .component()
        .additional_properties(prop2="test2")  # sets prop2 of the parent component to "test2"
        .representation()
```

I wonder if we should make this the default method and remove the `additional_properties: AdditionalProperties = None,` from the constructor methods?