### PR TITLE
Representation params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file, following t
 - Breaking: Renamed geometrical primitive `line` to `tube`
 - Breaking: Change multiple geometrical primitive parameters
 - Multi-state data model tweaks
+- Support for representation-specific parameters (customize presentation visuals)
 
 
 ## [v1.1.0] - 2024-12-09

--- a/molviewspec/app/api/examples.py
+++ b/molviewspec/app/api/examples.py
@@ -728,6 +728,21 @@ async def refs_example() -> MVSResponse:
     return PlainTextResponse(builder.get_state())
 
 
+@router.get("/repr-params")
+async def repr_params_example() -> MVSResponse:
+    """
+    Individual representations (cartoon, ball-and-stick, surface) can be further customized. The corresponding builder
+    function exposes additional method arguments depending on the chosen representation type.
+    """
+    builder = create_builder()
+    component = (
+        builder.download(url=_url_for_mmcif("4hhb")).parse(format="mmcif").model_structure(ref="structure").component()
+    )
+    component.representation(type="cartoon", size_factor=1.5, tubular_helices=True)
+    component.representation(type="surface", ignore_hydrogens=True).opacity(opacity=0.8)
+    return PlainTextResponse(builder.get_state())
+
+
 @router.get("/primitives/cube")
 async def primitives_cube_example() -> MVSResponse:
     """

--- a/molviewspec/app/api/examples.py
+++ b/molviewspec/app/api/examples.py
@@ -736,7 +736,7 @@ async def repr_params_example() -> MVSResponse:
     """
     builder = create_builder()
     component = (
-        builder.download(url=_url_for_mmcif("4hhb")).parse(format="mmcif").model_structure(ref="structure").component()
+        builder.download(url=_url_for_mmcif("1a23")).parse(format="mmcif").model_structure(ref="structure").component()
     )
     component.representation(type="cartoon", size_factor=1.5, tubular_helices=True)
     component.representation(type="surface", ignore_hydrogens=True).opacity(opacity=0.8)

--- a/molviewspec/molviewspec/builder.py
+++ b/molviewspec/molviewspec/builder.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 import math
 import os
 from abc import ABC, abstractmethod
-from typing import Literal, Self, Sequence
+from typing import Any, Literal, Self, Sequence, overload
 
 from pydantic import BaseModel, PrivateAttr
 
@@ -46,7 +46,7 @@ from molviewspec.nodes import (
     PrimitivesFromUriParams,
     PrimitivesParams,
     RefT,
-    RepresentationParams,
+    RepresentationTypeParams,
     RepresentationTypeT,
     SchemaFormatT,
     SchemaT,
@@ -78,17 +78,14 @@ class _BuilderProtocol(ABC):
 
     @property
     @abstractmethod
-    def _root(self) -> Root:
-        ...
+    def _root(self) -> Root: ...
 
     @property
     @abstractmethod
-    def _node(self) -> Node:
-        ...
+    def _node(self) -> Node: ...
 
     @abstractmethod
-    def _add_child(self, node: Node) -> None:
-        ...
+    def _add_child(self, node: Node) -> None: ...
 
 
 class _Base(BaseModel, _BuilderProtocol):
@@ -661,17 +658,82 @@ class Component(_Base, _FocusMixin):
     Builder step with operations relevant for a particular component.
     """
 
+    @overload
     def representation(
-        self, *, type: RepresentationTypeT = "cartoon", custom: CustomT = None, ref: RefT = None
+        self,
+        *,
+        type: Literal["cartoon"],
+        size_factor: float = None,
+        tubular_helices: bool = None,
+        custom: CustomT = None,
+        ref: RefT = None,
+    ) -> Representation:
+        """
+        Add a cartoon representation for this component.
+        :param type: the type of this representation ('cartoon')
+        :param size_factor: adjust the scale of the visuals (relative to 1.0)
+        :param tubular_helices: simplify helices to tubes
+        :param custom: optional, custom data to attach to this node
+        :param ref: optional, reference that can be used to access this node
+        :return: a builder that handles operations at representation level
+        """
+        ...
+
+    @overload
+    def representation(
+        self,
+        *,
+        type: Literal["ball_and_stick"],
+        ignore_hydrogens: bool = None,
+        size_factor: float = None,
+        custom: CustomT = None,
+        ref: RefT = None,
+    ) -> Representation:
+        """
+        Add a ball-and-stick representation for this component.
+        :param type: the type of this representation ('ball_and_stick')
+        :param ignore_hydrogens: draw hydrogen atoms?
+        :param size_factor: adjust the scale of the visuals (relative to 1.0)
+        :param custom: optional, custom data to attach to this node
+        :param ref: optional, reference that can be used to access this node
+        :return: a builder that handles operations at representation level
+        """
+        ...
+
+    @overload
+    def representation(
+        self,
+        *,
+        type: Literal["surface"],
+        ignore_hydrogens: bool = None,
+        size_factor: float = None,
+        custom: CustomT = None,
+        ref: RefT = None,
+    ) -> Representation:
+        """
+        Add a surface representation for this component.
+        :param type: the type of this representation ('surface')
+        :param ignore_hydrogens: draw hydrogen atoms?
+        :param size_factor: adjust the scale of the visuals (relative to 1.0)
+        :param custom: optional, custom data to attach to this node
+        :param ref: optional, reference that can be used to access this node
+        :return: a builder that handles operations at representation level
+        """
+        ...
+
+    def representation(
+        self, *, type: RepresentationTypeT = "cartoon", custom: CustomT = None, ref: RefT = None, **kwargs: Any
     ) -> Representation:
         """
         Add a representation for this component.
         :param type: the type of representation, defaults to 'cartoon'
         :param custom: optional, custom data to attach to this node
         :param ref: optional, reference that can be used to access this node
+        :param kwargs: optional, representation-specific params
         :return: a builder that handles operations at representation level
         """
-        params = make_params(RepresentationParams, locals())
+        params_class = RepresentationTypeParams.get(type)
+        params = make_params(params_class, locals(), **kwargs)
         node = Node(kind="representation", params=params)
         self._add_child(node)
         return Representation(node=node, root=self._root)

--- a/molviewspec/molviewspec/nodes.py
+++ b/molviewspec/molviewspec/nodes.py
@@ -5,7 +5,7 @@ Definitions of all 'nodes' used by the MolViewSpec format specification and its 
 from __future__ import annotations
 
 from datetime import datetime, timezone
-from typing import Any, Dict, Literal, Mapping, Optional, Tuple, Type, TypeVar, Union
+from typing import Any, Literal, Mapping, Optional, Tuple, TypeVar, Union
 from uuid import uuid4
 
 from pydantic import BaseModel, Field
@@ -439,26 +439,25 @@ class RepresentationParams(BaseModel):
 
 
 class CartoonParams(RepresentationParams):
+    type: Literal["cartoon"] = "cartoon"
     size_factor: Optional[float] = Field(description="Scales the corresponding visuals.")
     tubular_helices: Optional[bool] = Field(description="Simplify corkscrew helices to tubes.")
     # TODO support for variable size, e.g. based on b-factors?
 
 
 class BallAndStickParams(RepresentationParams):
+    type: Literal["ball_and_stick"] = "ball_and_stick"
     ignore_hydrogens: Optional[bool] = Field(descripton="Controls whether hydrogen atoms are drawn.")
     size_factor: Optional[float] = Field(description="Scales the corresponding visuals.")
 
 
 class SurfaceParams(RepresentationParams):
+    type: Literal["surface"] = "surface"
     ignore_hydrogens: Optional[bool] = Field(descripton="Controls whether hydrogen atoms are drawn.")
     size_factor: Optional[float] = Field(description="Scales the corresponding visuals.")
 
 
-RepresentationTypeParams: Dict[RepresentationTypeT, Type[Union[CartoonParams, BallAndStickParams, SurfaceParams]]] = {
-    "cartoon": CartoonParams,
-    "ball_and_stick": BallAndStickParams,
-    "surface": SurfaceParams,
-}
+RepresentationTypeParams = {t.__fields__["type"].default: t for t in (CartoonParams, BallAndStickParams, SurfaceParams)}
 
 
 SchemaT = Literal[

--- a/molviewspec/molviewspec/nodes.py
+++ b/molviewspec/molviewspec/nodes.py
@@ -5,7 +5,7 @@ Definitions of all 'nodes' used by the MolViewSpec format specification and its 
 from __future__ import annotations
 
 from datetime import datetime, timezone
-from typing import Any, Literal, Mapping, Optional, Tuple, TypeVar, Union
+from typing import Any, Dict, Literal, Mapping, Optional, Tuple, Type, TypeVar, Union
 from uuid import uuid4
 
 from pydantic import BaseModel, Field
@@ -436,6 +436,29 @@ class RepresentationParams(BaseModel):
     """
 
     type: RepresentationTypeT = Field(description="Representation type, i.e. cartoon, ball-and-stick, etc.")
+
+
+class CartoonParams(RepresentationParams):
+    size_factor: Optional[float] = Field(description="Scales the corresponding visuals.")
+    tubular_helices: Optional[bool] = Field(description="Simplify corkscrew helices to tubes.")
+    # TODO support for variable size, e.g. based on b-factors?
+
+
+class BallAndStickParams(RepresentationParams):
+    ignore_hydrogens: Optional[bool] = Field(descripton="Controls whether hydrogen atoms are drawn.")
+    size_factor: Optional[float] = Field(description="Scales the corresponding visuals.")
+
+
+class SurfaceParams(RepresentationParams):
+    ignore_hydrogens: Optional[bool] = Field(descripton="Controls whether hydrogen atoms are drawn.")
+    size_factor: Optional[float] = Field(description="Scales the corresponding visuals.")
+
+
+RepresentationTypeParams: Dict[RepresentationTypeT, Type[Union[CartoonParams, BallAndStickParams, SurfaceParams]]] = {
+    "cartoon": CartoonParams,
+    "ball_and_stick": BallAndStickParams,
+    "surface": SurfaceParams,
+}
 
 
 SchemaT = Literal[

--- a/molviewspec/molviewspec/utils.py
+++ b/molviewspec/molviewspec/utils.py
@@ -11,15 +11,18 @@ def make_params(params_type: Type[TParams], values=None, /, **more_values: objec
     if values is None:
         values = {}
     result = {}
+    consumed = set()
 
     # propagate custom properties
     if values:
         custom_values = values.get("custom")
         if custom_values is not None:
             result["custom"] = custom_values
+            consumed.add("custom")
         ref = values.get("ref")
         if ref is not None:
             result["ref"] = ref
+            consumed.add("ref")
 
     for field in params_type.__fields__.values():
         # must use alias here to properly resolve goodies like `schema_`
@@ -27,10 +30,17 @@ def make_params(params_type: Type[TParams], values=None, /, **more_values: objec
 
         if more_values.get(key) is not None:
             result[key] = more_values[key]
+            consumed.add(key)
         elif values.get(key) is not None:
             result[key] = values[key]
+            consumed.add(key)
         elif field.default is not None:  # currently not used
             result[key] = field.default
+            consumed.add(key)
+
+    non_model_keys = set(more_values.keys()) - consumed
+    if non_model_keys:
+        raise ValueError(f"Encountered unknown attribute on {params_type}: {non_model_keys}")
 
     return result  # type: ignore
 

--- a/molviewspec/molviewspec/utils.py
+++ b/molviewspec/molviewspec/utils.py
@@ -11,18 +11,16 @@ def make_params(params_type: Type[TParams], values=None, /, **more_values: objec
     if values is None:
         values = {}
     result = {}
-    consumed = set()
+    consumed_more_values = set()
 
     # propagate custom properties
     if values:
         custom_values = values.get("custom")
         if custom_values is not None:
             result["custom"] = custom_values
-            consumed.add("custom")
         ref = values.get("ref")
         if ref is not None:
             result["ref"] = ref
-            consumed.add("ref")
 
     for field in params_type.__fields__.values():
         # must use alias here to properly resolve goodies like `schema_`
@@ -30,15 +28,13 @@ def make_params(params_type: Type[TParams], values=None, /, **more_values: objec
 
         if more_values.get(key) is not None:
             result[key] = more_values[key]
-            consumed.add(key)
+            consumed_more_values.add(key)
         elif values.get(key) is not None:
             result[key] = values[key]
-            consumed.add(key)
         elif field.default is not None:  # currently not used
             result[key] = field.default
-            consumed.add(key)
 
-    non_model_keys = set(more_values.keys()) - consumed
+    non_model_keys = set(more_values.keys()) - consumed_more_values
     if non_model_keys:
         raise ValueError(f"Encountered unknown attribute on {params_type}: {non_model_keys}")
 


### PR DESCRIPTION
# Description
Basic support for representation-specific parameters.

Any other params that we want to support at this point?

Should we add some validation? Things like `component.representation(type="cartoon", ignore_hydrogens=True)` can be done, but `ignore_hydrogens` won't be propagated to the final JSON.

## Actions

- [ ] Added description of changes to the `[Unreleased]` section of `CHANGELOG.md`
- [x] (Optional but encouraged) Added example(s) for new feature(s) in this PR to `app/api/examples.py`