### PR TITLE
Basic IHM restraints support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ All notable changes to this project will be documented in this file, following t
 - Breaking: Change multiple geometrical primitive parameters
 - Multi-state data model tweaks
 - Support for representation-specific parameters (customize presentation visuals)
+- Add "coarse" component kind
+- Add "spacefill" representation
+- Add I/HM basic restraints example
 
 
 ## [v1.1.0] - 2024-12-09

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,9 @@ All notable changes to this project will be documented in this file, following t
 - Breaking: Change multiple geometrical primitive parameters
 - Multi-state data model tweaks
 - Support for representation-specific parameters (customize presentation visuals)
-- Add "coarse" component kind
-- Add "spacefill" representation
+- Add `coarse` component kind
+- Add `spacefill` representation
+- Add `element_granularity` field to component expressions
 - Add I/HM basic restraints example
 
 

--- a/molviewspec/app/api/examples.py
+++ b/molviewspec/app/api/examples.py
@@ -800,8 +800,12 @@ async def ihm_basic_restraints_example() -> MVSResponse:
     builder = create_builder()
     structure = builder.download(url="https://pdb-ihm.org/cif/8zz1.cif").parse(format="mmcif").model_structure()
 
-    structure.component(selector="coarse").representation(type="spacefill")
-    structure.component(selector="polymer").representation(type="cartoon")
+    structure.component(selector="coarse").representation(type="spacefill").color(
+        custom={"molstar_use_default_coloring": True}
+    )
+    structure.component(selector="polymer").representation(type="cartoon").color(
+        custom={"molstar_use_default_coloring": True}
+    )
 
     # Extracted manually from ihm_cross_link_restraint category of 8zz1.cif
     RESTRAINTS = [
@@ -816,12 +820,8 @@ async def ihm_basic_restraints_example() -> MVSResponse:
     primitives = structure.primitives()
     for e1, a1, s1, e2, a2, s2 in RESTRAINTS:
         primitives.tube(
-            start=ComponentExpression(
-                element_granularity="coarse", label_entity_id=e1, label_asym_id=a1, label_seq_id=s1
-            ),
-            end=ComponentExpression(
-                element_granularity="coarse", label_entity_id=e2, label_asym_id=a2, label_seq_id=s2
-            ),
+            start=ComponentExpression(label_entity_id=e1, label_asym_id=a1, label_seq_id=s1),
+            end=ComponentExpression(label_entity_id=e2, label_asym_id=a2, label_seq_id=s2),
             color="red",
             radius=1,
             dash_length=1,

--- a/molviewspec/app/api/examples.py
+++ b/molviewspec/app/api/examples.py
@@ -792,6 +792,44 @@ async def primitives_multi_structure_example() -> MVSResponse:
     return PlainTextResponse(builder.get_state())
 
 
+@router.get("/ihm/basic-restraints")
+async def ihm_basic_restraints_example() -> MVSResponse:
+    """
+    Loads an I/HM structure and renders restraints as tube primitives
+    """
+    builder = create_builder()
+    structure = builder.download(url="https://pdb-ihm.org/cif/8zz1.cif").parse(format="mmcif").model_structure()
+
+    structure.component(selector="coarse").representation(type="spacefill")
+    structure.component(selector="polymer").representation(type="cartoon")
+
+    # Extracted manually from ihm_cross_link_restraint category of 8zz1.cif
+    RESTRAINTS = [
+        [3, "C", 17, 3, "C", 412],
+        [3, "C", 17, 3, "C", 735],
+        [3, "C", 206, 3, "C", 217],
+        [3, "C", 384, 3, "C", 362],
+        [3, "C", 400, 3, "C", 530],
+        # ...
+    ]
+
+    primitives = structure.primitives()
+    for e1, a1, s1, e2, a2, s2 in RESTRAINTS:
+        primitives.tube(
+            start=ComponentExpression(
+                element_granularity="coarse", label_entity_id=e1, label_asym_id=a1, label_seq_id=s1
+            ),
+            end=ComponentExpression(
+                element_granularity="coarse", label_entity_id=e2, label_asym_id=a2, label_seq_id=s2
+            ),
+            color="red",
+            radius=1,
+            dash_length=1,
+        )
+
+    return PlainTextResponse(builder.get_state())
+
+
 ##############################################################################
 # meta endpoints
 

--- a/molviewspec/molviewspec/builder.py
+++ b/molviewspec/molviewspec/builder.py
@@ -704,6 +704,27 @@ class Component(_Base, _FocusMixin):
     def representation(
         self,
         *,
+        type: Literal["spacefill"],
+        ignore_hydrogens: bool = None,
+        size_factor: float = None,
+        custom: CustomT = None,
+        ref: RefT = None,
+    ) -> Representation:
+        """
+        Add a spacefill representation for this component.
+        :param type: the type of this representation ('ball_and_stick')
+        :param ignore_hydrogens: draw hydrogen atoms?
+        :param size_factor: adjust the scale of the visuals (relative to 1.0)
+        :param custom: optional, custom data to attach to this node
+        :param ref: optional, reference that can be used to access this node
+        :return: a builder that handles operations at representation level
+        """
+        ...
+
+    @overload
+    def representation(
+        self,
+        *,
         type: Literal["surface"],
         ignore_hydrogens: bool = None,
         size_factor: float = None,

--- a/molviewspec/molviewspec/builder.py
+++ b/molviewspec/molviewspec/builder.py
@@ -840,7 +840,7 @@ class Representation(_Base):
     def color(
         self,
         *,
-        color: ColorT,
+        color: ColorT | None = None,
         selector: ComponentSelectorT | ComponentExpression | list[ComponentExpression] | None = None,
         custom: CustomT = None,
     ) -> Representation:

--- a/molviewspec/molviewspec/nodes.py
+++ b/molviewspec/molviewspec/nodes.py
@@ -235,13 +235,17 @@ class StructureParams(BaseModel):
     ijk_max: Optional[Vec3[int]] = Field(description="Top-right Miller indices")
 
 
-ComponentSelectorT = Literal["all", "polymer", "protein", "nucleic", "branched", "ligand", "ion", "water"]
+ComponentSelectorT = Literal["all", "polymer", "protein", "nucleic", "branched", "ligand", "ion", "water", "coarse"]
 
 
 class ComponentExpression(BaseModel):
     """
     Component expressions are used to make selections.
     """
+
+    element_granularity: Optional[Literal["atom", "coarse"]] = Field(
+        description="Determines the element granularity this expression targets"
+    )
 
     label_entity_id: Optional[str] = Field(description="Select an entity by its identifier")
     label_asym_id: Optional[str] = Field(
@@ -277,7 +281,7 @@ class ComponentExpression(BaseModel):
     atom_index: Optional[int] = Field(description="0-based atom index in the source file")
 
 
-RepresentationTypeT = Literal["ball_and_stick", "cartoon", "surface"]
+RepresentationTypeT = Literal["ball_and_stick", "spacefill", "cartoon", "surface"]
 ColorNamesT = Literal[
     "aliceblue",
     "antiquewhite",
@@ -451,13 +455,21 @@ class BallAndStickParams(RepresentationParams):
     size_factor: Optional[float] = Field(description="Scales the corresponding visuals.")
 
 
+class SpacefillParams(RepresentationParams):
+    type: Literal["spacefill"] = "spacefill"
+    ignore_hydrogens: Optional[bool] = Field(descripton="Controls whether hydrogen atoms are drawn.")
+    size_factor: Optional[float] = Field(description="Scales the corresponding visuals.")
+
+
 class SurfaceParams(RepresentationParams):
     type: Literal["surface"] = "surface"
     ignore_hydrogens: Optional[bool] = Field(descripton="Controls whether hydrogen atoms are drawn.")
     size_factor: Optional[float] = Field(description="Scales the corresponding visuals.")
 
 
-RepresentationTypeParams = {t.__fields__["type"].default: t for t in (CartoonParams, BallAndStickParams, SurfaceParams)}
+RepresentationTypeParams = {
+    t.__fields__["type"].default: t for t in (CartoonParams, BallAndStickParams, SpacefillParams, SurfaceParams)
+}
 
 
 SchemaT = Literal[

--- a/molviewspec/molviewspec/nodes.py
+++ b/molviewspec/molviewspec/nodes.py
@@ -243,10 +243,6 @@ class ComponentExpression(BaseModel):
     Component expressions are used to make selections.
     """
 
-    element_granularity: Optional[Literal["atom", "coarse"]] = Field(
-        description="Determines the element granularity this expression targets"
-    )
-
     label_entity_id: Optional[str] = Field(description="Select an entity by its identifier")
     label_asym_id: Optional[str] = Field(
         description="Select a chain using its standard, programmatically-assigned identifier"
@@ -570,7 +566,7 @@ class ColorInlineParams(ComponentInlineParams):
     Color based on function arguments.
     """
 
-    color: ColorT = Field(description="Color using SVG color names or RGB hex code")
+    color: Optional[ColorT] = Field(description="Color using SVG color names or RGB hex code")
 
 
 class ColorFromUriParams(_DataFromUriParams):


### PR DESCRIPTION
<!-- Thank you for contributing to mol-view-spec -->

# Description

Adds support for:

- [x] `coarse` components
- [x] Spacefill representation
- [x] `element_granularity` in component expressions

## Actions

- [x] Added description of changes to the `[Unreleased]` section of `CHANGELOG.md`
- [x] (Optional but encouraged) Added example(s) for new feature(s) in this PR to `app/api/examples.py`