### PR TITLE
Volume Server support + Add carbohydrate representation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ All notable changes to this project will be documented in this file, following t
 - Add `element_granularity` field to component expressions
 - Add I/HM basic restraints example
 - Add primitives: ellipse, ellipsoid, box, arrow
-- Add basic support for volumetric data
+- Add basic support for volumetric data (map, volume server)
 - Add membrane orientation examples
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file, following t
 - Support for representation-specific parameters (customize presentation visuals)
 - Add `coarse` component kind
 - Add `spacefill` representation
+- Add `carbohydrate` representation
 - Add `element_granularity` field to component expressions
 - Add I/HM basic restraints example
 - Add primitives: ellipse, ellipsoid, box, arrow

--- a/molviewspec/app/api/examples.py
+++ b/molviewspec/app/api/examples.py
@@ -1403,6 +1403,23 @@ async def testing_components_example() -> MVSResponse:
     return PlainTextResponse(builder.get_state())
 
 
+@router.get("/testing/carbs")
+async def testing_components_example() -> MVSResponse:
+    """
+    Return state demonstrating carbohydrate representation
+    """
+    builder = create_builder()
+
+    struct = builder.download(url=_url_for_mmcif("5t3x")).parse(format="mmcif").model_structure()
+    struct.component(selector="polymer").representation(type="cartoon").color(color="orange")
+    struct.component(selector="branched").representation(type="ball_and_stick").color(color="green")
+    struct.component(selector="branched").representation(type="carbohydrate").color(
+        custom={"molstar_use_default_coloring": True}
+    )
+
+    return PlainTextResponse(builder.get_state())
+
+
 @router.get("/testing/color_from_source")
 async def testing_color_from_source_example(tooltips: bool = False) -> MVSResponse:
     """

--- a/molviewspec/app/api/examples.py
+++ b/molviewspec/app/api/examples.py
@@ -1033,9 +1033,9 @@ async def volume_map_example() -> MVSResponse:
 
 
 @router.get("/volume/volume-server")
-async def volume_map_example() -> MVSResponse:
+async def volume_server_map_example() -> MVSResponse:
     """
-    Renders a volume in MAP format
+    Renders a volume obtained from the Mol* Volume Server
     """
 
     builder = create_builder()

--- a/molviewspec/molviewspec/builder.py
+++ b/molviewspec/molviewspec/builder.py
@@ -751,6 +751,25 @@ class Component(_Base, _FocusMixin):
     def representation(
         self,
         *,
+        type: Literal["carbohydrate"],
+        size_factor: float = None,
+        custom: CustomT = None,
+        ref: RefT = None,
+    ) -> Representation:
+        """
+        Add a carbohydrate representation for this component.
+        :param type: the type of this representation ('carbohydrate')
+        :param size_factor: adjust the scale of the visuals (relative to 1.0)
+        :param custom: optional, custom data to attach to this node
+        :param ref: optional, reference that can be used to access this node
+        :return: a builder that handles operations at representation level
+        """
+        ...
+
+    @overload
+    def representation(
+        self,
+        *,
         type: Literal["surface"],
         ignore_hydrogens: bool = None,
         size_factor: float = None,

--- a/molviewspec/molviewspec/builder.py
+++ b/molviewspec/molviewspec/builder.py
@@ -432,11 +432,13 @@ class Parse(_Base):
     def volume(
         self,
         *,
+        channel_id: str | None = None,
         custom: CustomT = None,
         ref: RefT = None,
     ) -> Volume:
         """
         Create volume node.
+        :param channel_id: optional, channel identifier
         :param custom: optional, custom data to attach to this node
         :param ref: optional, reference that can be used to access this node
         :return: a builder that handles operations at structure level

--- a/molviewspec/molviewspec/nodes.py
+++ b/molviewspec/molviewspec/nodes.py
@@ -468,6 +468,11 @@ class SpacefillParams(RepresentationParams):
     size_factor: Optional[float] = Field(description="Scales the corresponding visuals.")
 
 
+class CarbohydrateParams(RepresentationParams):
+    type: Literal["carbohydrate"] = "carbohydrate"
+    size_factor: Optional[float] = Field(description="Scales the corresponding visuals.")
+
+
 class SurfaceParams(RepresentationParams):
     type: Literal["surface"] = "surface"
     ignore_hydrogens: Optional[bool] = Field(descripton="Controls whether hydrogen atoms are drawn.")
@@ -475,7 +480,8 @@ class SurfaceParams(RepresentationParams):
 
 
 RepresentationTypeParams = {
-    t.__fields__["type"].default: t for t in (CartoonParams, BallAndStickParams, SpacefillParams, SurfaceParams)
+    t.__fields__["type"].default: t
+    for t in (CartoonParams, BallAndStickParams, SpacefillParams, CarbohydrateParams, SurfaceParams)
 }
 
 

--- a/molviewspec/molviewspec/nodes.py
+++ b/molviewspec/molviewspec/nodes.py
@@ -242,6 +242,8 @@ class VolumeParams(BaseModel):
     Volume node, describing how to load and render volumetric data.
     """
 
+    channel_id: Optional[str] = Field(description="ID of the channel to load from the source data.")
+
 
 ComponentSelectorT = Literal["all", "polymer", "protein", "nucleic", "branched", "ligand", "ion", "water", "coarse"]
 


### PR DESCRIPTION
<!-- Thank you for contributing to mol-view-spec -->

# Description

- [x] Add support for volume server data
- [x] Add `carbohydrate` representation

## Actions

- [x] Added description of changes to the `[Unreleased]` section of `CHANGELOG.md`
- [x] (Optional but encouraged) Added example(s) for new feature(s) in this PR to `app/api/examples.py`