### PR TITLE
Improve error message for unknown/misspelled repr types

### DIFF
--- a/molviewspec/molviewspec/utils.py
+++ b/molviewspec/molviewspec/utils.py
@@ -8,6 +8,9 @@ TParams = TypeVar("TParams", bound=BaseModel)
 
 
 def make_params(params_type: Type[TParams], values=None, /, **more_values: object) -> Mapping[str, Any]:
+    if params_type is None:
+        raise ValueError("Param type couldn't be resolved to a concrete class -- did you misspell the value of `type`?")
+
     if values is None:
         values = {}
     result = {}


### PR DESCRIPTION
# Description
A user reported that typos like ```.representation(type="spacefilling")``` currently result in: `AttributeError: 'NoneType' object has no attribute '__fields__'`.

This error message should be a bit more helpful.

## Actions

- [ ] Added description of changes to the `[Unreleased]` section of `CHANGELOG.md`
- [ ] (Optional but encouraged) Added example(s) for new feature(s) in this PR to `app/api/examples.py`