### PR TITLE
add mvsj to mvsx feature, add tests, add examples endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file, following t
 ## [Unreleased]
 
 - Add `auth/label_comp_id` to `ComponentExpression`
+- Add MVSJ to MVSX archive functionality
+  - Create self-contained archives with all external resources for offline use
+  - Functions for finding and updating URI references in MVSJ files
+  - Download external resources and package them with MVSJ into a ZIP archive
+  - Extract archives to recover original files with localized references
 
 ## [v1.3.0] - 2025-03-18
 

--- a/molviewspec/app/api/examples.py
+++ b/molviewspec/app/api/examples.py
@@ -2649,3 +2649,94 @@ def _dot(a, b):
 
 def _cross(a, b):
     return [a[1] * b[2] - a[2] * b[1], a[2] * b[0] - a[0] * b[2], a[0] * b[1] - a[1] * b[0]]
+
+
+@router.get("/testing/mvsj_to_mvsx")
+async def testing_mvsj_to_mvsx(id: str = "1cbs", download: bool = True) -> Response:
+    """
+    Create and use a self-contained MVSX archive with all external resources for offline use.
+
+    This example demonstrates how to:
+    1. Create an MVSX archive from a MVSJ visualization
+    2. Include all external resources in the archive
+    3. Extract and verify the archive contents
+
+    :param id: PDB entry ID to visualize
+    :param download: Whether to download external resources (default: True)
+    :return: The MVSX archive as a file attachment for download
+    """
+    import os
+    import tempfile
+    import json
+    from molviewspec.utils import mvsj_to_mvsx, extract_mvsx
+
+    # Create a simple visualization
+    builder = create_builder()
+    (
+        builder.download(url=_url_for_mmcif(id))
+        .parse(format="mmcif")
+        .model_structure()
+        .component()
+        .representation()
+        .color(color="blue")
+    )
+
+    # Get the MVSJ content
+    mvsj_content = builder.get_state(
+        title=f"MVSX Archive Example - {id}",
+        description="This visualization is packaged as an MVSX archive with all external resources included.",
+        description_format="plaintext",
+    )
+
+    # Use a single persistent output directory for all files
+    output_dir = os.path.join(tempfile.gettempdir(), "mvsx_archives")
+    os.makedirs(output_dir, exist_ok=True)
+
+    try:
+        # Define all the paths we'll need
+        mvsj_path = os.path.join(output_dir, f"{id}.mvsj")
+        mvsx_path = os.path.join(output_dir, f"{id}.mvsx")
+        extract_dir = os.path.join(output_dir, f"{id}_extracted")
+
+        # Create the extract directory before using it
+        os.makedirs(extract_dir, exist_ok=True)
+
+        # Save MVSJ to a file
+        with open(mvsj_path, 'w', encoding='utf-8') as f:
+            f.write(mvsj_content)
+
+        # Create the MVSX archive
+        result = mvsj_to_mvsx(mvsj_path, mvsx_path, download_external=download)
+
+        if not result:
+            return PlainTextResponse(f"Failed to create MVSX archive for {id}", status_code=500)
+
+        # Extract MVSX to verify its contents
+        index_path = extract_mvsx(mvsx_path, extract_dir)
+
+        if not index_path or not os.path.exists(index_path):
+            return PlainTextResponse(f"Failed to extract MVSX archive for {id}", status_code=500)
+
+        # Read the extracted index.mvsj to include in response headers
+        with open(index_path, 'r', encoding='utf-8') as f:
+            extracted_mvsj = json.load(f)
+
+        # Include details about the archive in the response headers
+        original_url = None
+        for child in extracted_mvsj.get("root", {}).get("children", []):
+            if child.get("kind") == "download" and "params" in child and "url" in child["params"]:
+                original_url = child["params"]["url"]
+                break
+
+        # Return the MVSX file as an attachment for download
+        return FileResponse(
+            mvsx_path,
+            media_type="application/zip",
+            filename=f"{id}.mvsx",
+            headers={
+                "X-MVSX-Original-URL": original_url or "Not found",
+                "X-MVSX-Contents": str(os.listdir(extract_dir)),
+            }
+        )
+    except Exception as e:
+        return PlainTextResponse(f"Error creating MVSX archive: {str(e)}", status_code=500)

--- a/molviewspec/molviewspec/utils.py
+++ b/molviewspec/molviewspec/utils.py
@@ -1,4 +1,12 @@
 from typing import Any, Mapping, Type, TypeVar
+import json
+import os
+import zipfile
+import urllib.request
+from urllib.parse import urlparse, urljoin
+import logging
+from pathlib import Path
+import tempfile
 
 from pydantic import BaseModel
 
@@ -62,3 +70,271 @@ def get_major_version_tag() -> str:
     version_parts = __version__.split(".")
     major = ".".join(version_parts[:2])
     return major
+
+
+def find_uri_references(node: dict, uri_references: set) -> None:
+    """
+    Recursively finds URI references in an MVSJ node structure.
+
+    Args:
+        node (dict): An MVSJ node to search
+        uri_references (set): Set to collect found URI references
+    """
+    if not isinstance(node, dict):
+        return
+
+    # Check for URI parameters in this node
+    if "params" in node and isinstance(node["params"], dict):
+        params = node["params"]
+
+        # Check for URI field directly
+        if "uri" in params and isinstance(params["uri"], str):
+            uri = params["uri"]
+            uri_references.add(uri)
+
+        # Check for URL field (for downloads)
+        if "url" in params and isinstance(params["url"], str):
+            url = params["url"]
+            uri_references.add(url)
+
+    # Recursively check children
+    if "children" in node and isinstance(node["children"], list):
+        for child in node["children"]:
+            find_uri_references(child, uri_references)
+
+
+def update_uri_references(node: dict, uri_mapping: dict) -> None:
+    """
+    Recursively updates URI references in an MVSJ node structure.
+
+    Args:
+        node (dict): An MVSJ node to update
+        uri_mapping (dict): Mapping from original URIs to local filenames
+    """
+    if not isinstance(node, dict):
+        return
+
+    # Update URI parameters in this node
+    if "params" in node and isinstance(node["params"], dict):
+        params = node["params"]
+
+        # Update 'uri' parameter if present
+        if "uri" in params and params["uri"] in uri_mapping:
+            params["uri"] = uri_mapping[params["uri"]]
+
+        # Update 'url' parameter if present
+        if "url" in params and params["url"] in uri_mapping:
+            params["url"] = uri_mapping[params["url"]]
+
+    # Recursively update children
+    if "children" in node and isinstance(node["children"], list):
+        for child in node["children"]:
+            update_uri_references(child, uri_mapping)
+
+
+def mvsj_to_mvsx(
+    input_mvsj_path: str | os.PathLike,
+    output_mvsx_path: str | os.PathLike,
+    download_external: bool = True,  # Default is True to always download external files
+    base_url: str = None,
+    logger: logging.Logger = None,
+) -> bool:
+    """
+    Create an MVSX archive from an MVSJ file, automatically including all referenced files.
+
+    The function will:
+    1. Parse the MVSJ file to identify URI references
+    2. Download external resources (enabled by default)
+    3. Package all files into an MVSX archive (which is a ZIP file)
+    4. Update the MVSJ structure to use local references
+
+    Args:
+        input_mvsj_path (str | os.PathLike): Path to the input MVSJ file
+        output_mvsx_path (str | os.PathLike): Path for the output MVSX file
+        download_external (bool): Whether to download external resources. Defaults to True.
+        base_url (str, optional): Base URL for resolving relative URLs. Defaults to None.
+        logger (logging.Logger, optional): Logger to use. If None, logs are not produced.
+
+    Returns:
+        bool: True if successful, False otherwise
+    """
+    # Set up logging
+    if logger is None:
+        logger = logging.getLogger("mvsx_creator")
+        logger.addHandler(logging.NullHandler())
+
+    logger.info(f"Creating MVSX from {input_mvsj_path} to {output_mvsx_path}")
+
+    # Convert to Path objects for easier path manipulation
+    input_path = Path(input_mvsj_path)
+    output_path = Path(output_mvsx_path)
+
+    # Read the input MVSJ file
+    try:
+        with open(input_path, 'r', encoding='utf-8') as f:
+            mvsj_data = json.load(f)
+    except Exception as e:
+        logger.error(f"Error reading MVSJ file: {e}")
+        return False
+
+    # Create a temporary directory for downloaded files
+    with tempfile.TemporaryDirectory() as temp_dir:
+        # Find all URI references
+        uri_references = set()
+
+        # Start from root node
+        if "root" in mvsj_data:
+            find_uri_references(mvsj_data["root"], uri_references)
+
+        # If it's a multi-state file, check each snapshot
+        if "snapshots" in mvsj_data and isinstance(mvsj_data["snapshots"], list):
+            for snapshot in mvsj_data["snapshots"]:
+                if "root" in snapshot:
+                    find_uri_references(snapshot["root"], uri_references)
+
+        # Create a mapping from original URIs to archive paths
+        uri_mapping = {}
+
+        # Process each URI reference
+        for uri in uri_references:
+            try:
+                parsed_uri = urlparse(uri)
+
+                # Check if it's an external URI that needs to be downloaded
+                is_external = parsed_uri.scheme in ('http', 'https', 'ftp')
+
+                if is_external and download_external:
+                    # Form the full URL
+                    if base_url and not parsed_uri.netloc:
+                        # Relative URL with base_url provided
+                        full_url = urljoin(base_url, uri)
+                    else:
+                        full_url = uri
+
+                    logger.info(f"Downloading external resource: {full_url}")
+
+                    # Extract filename from URL path
+                    filename = os.path.basename(parsed_uri.path)
+                    if not filename:
+                        # Generate a name if none is available
+                        filename = f"resource_{len(uri_mapping)}"
+
+                    # Ensure we have a unique filename
+                    local_path = os.path.join(temp_dir, filename)
+                    counter = 1
+                    while os.path.exists(local_path):
+                        name, ext = os.path.splitext(filename)
+                        filename = f"{name}_{counter}{ext}"
+                        local_path = os.path.join(temp_dir, filename)
+                        counter += 1
+
+                    # Download the file
+                    try:
+                        urllib.request.urlretrieve(full_url, local_path)
+                        # Add to the mapping
+                        uri_mapping[uri] = filename
+                    except Exception as e:
+                        logger.error(f"Failed to download {full_url}: {e}")
+
+                elif not is_external:
+                    # Local file reference
+                    local_file_path = input_path.parent / uri
+                    if local_file_path.exists():
+                        logger.info(f"Found local file: {local_file_path}")
+                        # Keep the same relative path in the archive
+                        uri_mapping[uri] = uri
+                    else:
+                        logger.warning(
+                            f"Local file not found: {local_file_path}"
+                        )
+
+            except Exception as e:
+                logger.error(f"Error processing URI {uri}: {e}")
+
+        # Update the MVSJ structure to use local references
+        if "root" in mvsj_data:
+            update_uri_references(mvsj_data["root"], uri_mapping)
+
+        if "snapshots" in mvsj_data and isinstance(mvsj_data["snapshots"], list):
+            for snapshot in mvsj_data["snapshots"]:
+                if "root" in snapshot:
+                    update_uri_references(snapshot["root"], uri_mapping)
+
+        # Create the MVSX archive
+        try:
+            with zipfile.ZipFile(output_path, mode='w') as z:
+                # Add the modified MVSJ as index.mvsj
+                index_mvsj_path = os.path.join(temp_dir, "index.mvsj")
+                with open(index_mvsj_path, 'w', encoding='utf-8') as f:
+                    json.dump(mvsj_data, f, ensure_ascii=False, indent=2)
+
+                z.write(index_mvsj_path, arcname="index.mvsj")
+
+                # Add all referenced local files
+                for uri, archive_path in uri_mapping.items():
+                    if not urlparse(uri).scheme or not download_external:
+                        # This is a local file or we're not downloading
+                        source_path = input_path.parent / uri
+                        if source_path.exists():
+                            z.write(source_path, arcname=archive_path)
+                    elif download_external:
+                        # This is a downloaded external file
+                        source_path = os.path.join(temp_dir, archive_path)
+                        if os.path.exists(source_path):
+                            z.write(source_path, arcname=archive_path)
+
+            logger.info(f"MVSX archive created successfully: {output_path}")
+            return True
+
+        except Exception as e:
+            logger.error(f"Error creating MVSX archive: {e}")
+            return False
+
+
+def extract_mvsx(
+    mvsx_path: str | os.PathLike,
+    output_dir: str | os.PathLike = None,
+    logger: logging.Logger = None,
+) -> str | None:
+    """
+    Extract an MVSX archive to a directory and return the path to the index.mvsj file.
+
+    Args:
+        mvsx_path (str | os.PathLike): Path to the MVSX file
+        output_dir (str | os.PathLike, optional): Directory to extract to. If None, creates a temporary directory.
+        logger (logging.Logger, optional): Logger to use. If None, logs are not produced.
+
+    Returns:
+        str | None: Path to the extracted index.mvsj file, or None if extraction failed
+    """
+    # Set up logging
+    if logger is None:
+        logger = logging.getLogger("mvsx_extractor")
+        logger.addHandler(logging.NullHandler())
+
+    try:
+        # Create output directory if needed
+        if output_dir is None:
+            output_dir = tempfile.mkdtemp()
+        else:
+            output_dir = Path(output_dir)
+            os.makedirs(output_dir, exist_ok=True)
+
+        logger.info(f"Extracting MVSX from {mvsx_path} to {output_dir}")
+
+        # Extract the archive
+        with zipfile.ZipFile(mvsx_path, 'r') as z:
+            z.extractall(output_dir)
+
+        # Find the index.mvsj file
+        index_path = os.path.join(output_dir, "index.mvsj")
+        if os.path.exists(index_path):
+            logger.info(f"Successfully extracted index.mvsj to {index_path}")
+            return index_path
+        else:
+            logger.error("No index.mvsj found in the MVSX archive")
+            return None
+
+    except Exception as e:
+        logger.error(f"Error extracting MVSX archive: {e}")
+        return None

--- a/molviewspec/test_mvsj_to_mvsx.py
+++ b/molviewspec/test_mvsj_to_mvsx.py
@@ -1,0 +1,557 @@
+import json
+import os
+import tempfile
+import shutil
+import unittest
+import zipfile
+import logging
+from urllib.parse import urlparse
+import urllib.request
+
+from molviewspec.utils import (
+    find_uri_references,
+    update_uri_references,
+    mvsj_to_mvsx,
+    extract_mvsx
+)
+
+# Set up logging for tests
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger("mvsx_test")
+
+
+class TestMVSXFunctionality(unittest.TestCase):
+    """Test the MVSX file format conversion functionality."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        # Create temporary directory for tests
+        self.test_dir = tempfile.mkdtemp()
+        self.test_resources_dir = os.path.join(self.test_dir, "resources")
+        os.makedirs(self.test_resources_dir, exist_ok=True)
+
+        # Path to colab_examples directory - try multiple possible locations
+        script_dir = os.path.dirname(os.path.abspath(__file__))
+        potential_paths = [
+            # Look in ../test-data/colab_examples (relative to script)
+            os.path.join(os.path.dirname(script_dir), "test-data", "colab_examples"),
+            # Look in ./test-data/colab_examples (relative to current working directory)
+            os.path.join(os.getcwd(), "test-data", "colab_examples"),
+            # Fallback to direct path in case the script is run from a different location
+            os.path.join(script_dir, "test", "colab_examples")
+        ]
+
+        self.colab_examples_dir = None
+        for path in potential_paths:
+            if os.path.exists(path):
+                self.colab_examples_dir = path
+                break
+
+        if self.colab_examples_dir:
+            logger.info(f"Found colab_examples directory at: {self.colab_examples_dir}")
+        else:
+            logger.warning("Could not find colab_examples directory. Related tests will be skipped.")
+
+        # Create a simple test MVSJ file
+        self.simple_mvsj_path = os.path.join(self.test_dir, "simple.mvsj")
+        self.simple_mvsj_data = {
+            "root": {
+                "kind": "root",
+                "children": [
+                    {
+                        "kind": "download",
+                        "params": {
+                            "url": "local_file.cif"
+                        },
+                        "children": [
+                            {
+                                "kind": "parse",
+                                "params": {
+                                    "format": "mmcif"
+                                }
+                            }
+                        ]
+                    }
+                ]
+            },
+            "metadata": {
+                "version": "0.1",
+                "timestamp": "2023-11-27T12:05:32.145284"
+            }
+        }
+
+        with open(self.simple_mvsj_path, 'w') as f:
+            json.dump(self.simple_mvsj_data, f, indent=2)
+
+        # Create a local file referenced in the MVSJ
+        self.local_file_path = os.path.join(self.test_dir, "local_file.cif")
+        with open(self.local_file_path, 'w') as f:
+            f.write("data_test\n_entry.id TEST\n")
+
+        # Create a complex MVSJ with both local and remote references
+        self.complex_mvsj_path = os.path.join(self.test_dir, "complex.mvsj")
+        self.complex_mvsj_data = {
+            "root": {
+                "kind": "root",
+                "children": [
+                    {
+                        "kind": "download",
+                        "params": {
+                            "url": "local_file.cif"
+                        },
+                        "children": [
+                            {
+                                "kind": "parse",
+                                "params": {
+                                    "format": "mmcif"
+                                },
+                                "children": [
+                                    {
+                                        "kind": "structure",
+                                        "params": {
+                                            "type": "model"
+                                        },
+                                        "children": [
+                                            {
+                                                "kind": "component",
+                                                "params": {
+                                                    "selector": "all"
+                                                }
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "kind": "download",
+                        "params": {
+                            "url": "https://files.wwpdb.org/download/1cbs.cif"
+                        },
+                        "children": [
+                            {
+                                "kind": "parse",
+                                "params": {
+                                    "format": "mmcif"
+                                }
+                            }
+                        ]
+                    },
+                    {
+                        "kind": "tooltip_from_uri",
+                        "params": {
+                            "uri": "annotations.cif",
+                            "format": "cif",
+                            "category_name": "annotations",
+                            "field_name": "label",
+                            "block_header": "test_annotations",
+                            "schema": "residue_range"
+                        }
+                    }
+                ]
+            },
+            "metadata": {
+                "version": "0.1",
+                "title": "A test with MVS annotations",
+                "timestamp": "2024-06-01T10:00:00.000000+00:00"
+            }
+        }
+
+        with open(self.complex_mvsj_path, 'w') as f:
+            json.dump(self.complex_mvsj_data, f, indent=2)
+
+        # Create annotation file referenced in complex MVSJ
+        self.annotation_file_path = os.path.join(self.test_dir, "annotations.cif")
+        with open(self.annotation_file_path, 'w') as f:
+            f.write("data_test_annotations\n\nloop_\n_annotations.id\n_annotations.label\n1 'Test Label'\n")
+
+        # Create a multi-state MVSJ file
+        self.multistate_mvsj_path = os.path.join(self.test_dir, "multistate.mvsj")
+        self.multistate_mvsj_data = {
+            "kind": "multiple",
+            "metadata": {
+                "version": "1.1",
+                "title": "Multi-state Test",
+                "timestamp": "2024-06-01T10:00:00.000000+00:00"
+            },
+            "snapshots": [
+                {
+                    "root": {
+                        "kind": "root",
+                        "children": [
+                            {
+                                "kind": "download",
+                                "params": {
+                                    "url": "local_file.cif"
+                                }
+                            }
+                        ]
+                    },
+                    "metadata": {
+                        "title": "Snapshot 1",
+                        "key": "snapshot1",
+                        "linger_duration_ms": 1000
+                    }
+                },
+                {
+                    "root": {
+                        "kind": "root",
+                        "children": [
+                            {
+                                "kind": "download",
+                                "params": {
+                                    "url": "https://files.wwpdb.org/download/1cbs.cif"
+                                }
+                            }
+                        ]
+                    },
+                    "metadata": {
+                        "title": "Snapshot 2",
+                        "key": "snapshot2",
+                        "linger_duration_ms": 1000,
+                        "transition_duration_ms": 500
+                    }
+                }
+            ]
+        }
+
+        with open(self.multistate_mvsj_path, 'w') as f:
+            json.dump(self.multistate_mvsj_data, f, indent=2)
+
+    def tearDown(self):
+        """Tear down test fixtures."""
+        # Remove the temporary directory and all its contents
+        shutil.rmtree(self.test_dir)
+
+    def test_find_uri_references(self):
+        """Test finding URI references in MVSJ files."""
+        # Test with simple MVSJ
+        uri_references_simple = set()
+        find_uri_references(self.simple_mvsj_data["root"], uri_references_simple)
+        self.assertEqual(len(uri_references_simple), 1)
+        self.assertIn("local_file.cif", uri_references_simple)
+
+        # Test with complex MVSJ
+        uri_references_complex = set()
+        find_uri_references(self.complex_mvsj_data["root"], uri_references_complex)
+        self.assertEqual(len(uri_references_complex), 3)
+        self.assertIn("local_file.cif", uri_references_complex)
+        self.assertIn("https://files.wwpdb.org/download/1cbs.cif", uri_references_complex)
+        self.assertIn("annotations.cif", uri_references_complex)
+
+        # Test with multi-state MVSJ
+        uri_references_multistate = set()
+        for snapshot in self.multistate_mvsj_data["snapshots"]:
+            find_uri_references(snapshot["root"], uri_references_multistate)
+        self.assertEqual(len(uri_references_multistate), 2)
+        self.assertIn("local_file.cif", uri_references_multistate)
+        self.assertIn("https://files.wwpdb.org/download/1cbs.cif", uri_references_multistate)
+
+    def test_update_uri_references(self):
+        """Test updating URI references in MVSJ files."""
+        # Test with simple MVSJ
+        uri_mapping = {"local_file.cif": "updated_file.cif"}
+        updated_data = json.loads(json.dumps(self.simple_mvsj_data))  # Deep copy
+        update_uri_references(updated_data["root"], uri_mapping)
+        self.assertEqual(updated_data["root"]["children"][0]["params"]["url"], "updated_file.cif")
+
+        # Test with complex MVSJ
+        uri_mapping = {
+            "local_file.cif": "new_local.cif",
+            "https://files.wwpdb.org/download/1cbs.cif": "1cbs.cif",
+            "annotations.cif": "new_annotations.cif"
+        }
+        updated_data = json.loads(json.dumps(self.complex_mvsj_data))  # Deep copy
+        update_uri_references(updated_data["root"], uri_mapping)
+        self.assertEqual(updated_data["root"]["children"][0]["params"]["url"], "new_local.cif")
+        self.assertEqual(updated_data["root"]["children"][1]["params"]["url"], "1cbs.cif")
+        self.assertEqual(updated_data["root"]["children"][2]["params"]["uri"], "new_annotations.cif")
+
+    def test_create_mvsx_simple(self):
+        """Test creating a simple MVSX archive from MVSJ file."""
+        output_mvsx_path = os.path.join(self.test_dir, "simple.mvsx")
+
+        # Create MVSX file from simple MVSJ
+        result = mvsj_to_mvsx(
+            self.simple_mvsj_path,
+            output_mvsx_path,
+            download_external=True,
+            logger=logger
+        )
+        self.assertTrue(result)
+        self.assertTrue(os.path.exists(output_mvsx_path))
+
+        # Check MVSX contents
+        with zipfile.ZipFile(output_mvsx_path, 'r') as z:
+            files = z.namelist()
+            self.assertIn("index.mvsj", files)
+            self.assertIn("local_file.cif", files)
+
+            # Check that index.mvsj has updated URLs
+            with z.open("index.mvsj") as f:
+                mvsj_content = json.loads(f.read().decode('utf-8'))
+                url = mvsj_content["root"]["children"][0]["params"]["url"]
+                self.assertEqual(url, "local_file.cif")
+
+    def test_create_mvsx_complex(self):
+        """Test creating a complex MVSX archive from MVSJ with remote files."""
+        output_mvsx_path = os.path.join(self.test_dir, "complex.mvsx")
+
+        # Create MVSX file from complex MVSJ with external file download enabled
+        result = mvsj_to_mvsx(
+            self.complex_mvsj_path,
+            output_mvsx_path,
+            download_external=True,
+            logger=logger
+        )
+        self.assertTrue(result)
+        self.assertTrue(os.path.exists(output_mvsx_path))
+
+        # Check MVSX contents
+        with zipfile.ZipFile(output_mvsx_path, 'r') as z:
+            files = z.namelist()
+            self.assertIn("index.mvsj", files)
+            self.assertIn("local_file.cif", files)
+            self.assertIn("annotations.cif", files)
+
+            # Check if external files were downloaded or their URLs updated
+            with z.open("index.mvsj") as f:
+                mvsj_content = json.loads(f.read().decode('utf-8'))
+                remote_url = mvsj_content["root"]["children"][1]["params"]["url"]
+
+                # Either the URL is updated to a local file (if download succeeded)
+                # or it remains unchanged (if download failed)
+                if "1cbs.cif" in files:
+                    self.assertEqual(remote_url, "1cbs.cif")
+                else:
+                    self.assertEqual(remote_url, "https://files.wwpdb.org/download/1cbs.cif")
+
+    def test_create_mvsx_with_download(self):
+        """Test creating MVSX with downloading external files (mock download)."""
+        output_mvsx_path = os.path.join(self.test_dir, "download_test.mvsx")
+
+        # Create a modified version of complex MVSJ with a fake download URL that we'll mock
+        mock_mvsj_path = os.path.join(self.test_dir, "mock.mvsj")
+        mock_mvsj_data = json.loads(json.dumps(self.complex_mvsj_data))
+
+        # Change the URL to a local file that we'll pretend is remote
+        mock_url = "https://example.com/test.cif"
+        mock_mvsj_data["root"]["children"][1]["params"]["url"] = mock_url
+
+        with open(mock_mvsj_path, 'w') as f:
+            json.dump(mock_mvsj_data, f, indent=2)
+
+        # Create a mock "downloaded" file
+        mock_download_source = os.path.join(self.test_dir, "mock_download.cif")
+        with open(mock_download_source, 'w') as f:
+            f.write("data_mock\n_entry.id MOCK\n")
+
+        # Define a function to mock URL retrieval
+        original_urlretrieve = urllib.request.urlretrieve
+
+        def mock_urlretrieve(url, filename):
+            if url == mock_url:
+                shutil.copyfile(mock_download_source, filename)
+                return filename, None
+            return original_urlretrieve(url, filename)
+
+        # Patch the URL retrieval function
+        urllib.request.urlretrieve = mock_urlretrieve
+
+        try:
+            # Create MVSX file with our mocked download
+            result = mvsj_to_mvsx(
+                mock_mvsj_path,
+                output_mvsx_path,
+                download_external=True,
+                logger=logger
+            )
+            self.assertTrue(result)
+            self.assertTrue(os.path.exists(output_mvsx_path))
+
+            # Check MVSX contents
+            with zipfile.ZipFile(output_mvsx_path, 'r') as z:
+                files = z.namelist()
+                self.assertIn("index.mvsj", files)
+
+                # Get the filename that the mock URL was saved as
+                expected_filename = os.path.basename(urlparse(mock_url).path)
+                self.assertIn(expected_filename, files)
+
+                # Check that index.mvsj has updated URL
+                with z.open("index.mvsj") as f:
+                    mvsj_content = json.loads(f.read().decode('utf-8'))
+                    updated_url = mvsj_content["root"]["children"][1]["params"]["url"]
+                    self.assertEqual(updated_url, expected_filename)
+        finally:
+            # Restore original URL retrieval function
+            urllib.request.urlretrieve = original_urlretrieve
+
+    def test_extract_mvsx(self):
+        """Test extracting MVSX archive."""
+        # First, create an MVSX file
+        mvsx_path = os.path.join(self.test_dir, "extract_test.mvsx")
+        result = mvsj_to_mvsx(
+            self.simple_mvsj_path,
+            mvsx_path,
+            download_external=True,
+            logger=logger
+        )
+        self.assertTrue(result)
+
+        # Now extract it to a new directory
+        extract_dir = os.path.join(self.test_dir, "extracted")
+        os.makedirs(extract_dir, exist_ok=True)
+
+        index_path = extract_mvsx(
+            mvsx_path,
+            extract_dir,
+            logger=logger
+        )
+
+        # Check that extraction was successful
+        self.assertIsNotNone(index_path)
+        self.assertTrue(os.path.exists(index_path))
+        self.assertTrue(os.path.exists(os.path.join(extract_dir, "local_file.cif")))
+
+        # Load and verify the extracted MVSJ content
+        with open(index_path, 'r', encoding='utf-8') as f:
+            extracted_mvsj = json.load(f)
+            self.assertEqual(extracted_mvsj["metadata"]["version"], self.simple_mvsj_data["metadata"]["version"])
+            self.assertEqual(
+                extracted_mvsj["root"]["children"][0]["params"]["url"],
+                self.simple_mvsj_data["root"]["children"][0]["params"]["url"]
+            )
+
+    def test_multistate_mvsx(self):
+        """Test creating and extracting a multi-state MVSX archive."""
+        output_mvsx_path = os.path.join(self.test_dir, "multistate.mvsx")
+
+        # Create MVSX file from multi-state MVSJ
+        result = mvsj_to_mvsx(
+            self.multistate_mvsj_path,
+            output_mvsx_path,
+            download_external=True,
+            logger=logger
+        )
+        self.assertTrue(result)
+        self.assertTrue(os.path.exists(output_mvsx_path))
+
+        # Check MVSX contents
+        with zipfile.ZipFile(output_mvsx_path, 'r') as z:
+            files = z.namelist()
+            self.assertIn("index.mvsj", files)
+            self.assertIn("local_file.cif", files)
+
+            # Check that index.mvsj has the correct structure
+            with z.open("index.mvsj") as f:
+                mvsj_content = json.loads(f.read().decode('utf-8'))
+                self.assertEqual(mvsj_content["kind"], "multiple")
+                self.assertEqual(len(mvsj_content["snapshots"]), 2)
+
+                # Check first snapshot URL was updated
+                url1 = mvsj_content["snapshots"][0]["root"]["children"][0]["params"]["url"]
+                self.assertEqual(url1, "local_file.cif")
+
+                # Check second snapshot URL - with download_external=True, it might be changed to local file
+                url2 = mvsj_content["snapshots"][1]["root"]["children"][0]["params"]["url"]
+
+                # Either the URL is updated to a local file (if download succeeded)
+                # or it remains unchanged (if download failed)
+                if "1cbs.cif" in files:
+                    self.assertEqual(url2, "1cbs.cif")
+                else:
+                    self.assertEqual(url2, "https://files.wwpdb.org/download/1cbs.cif")
+
+    def test_colab_examples(self):
+        """Test creating MVSX archives from example MVSJ files in ../test-data/colab_examples directory."""
+        # Skip test if colab_examples directory doesn't exist
+        if not os.path.exists(self.colab_examples_dir):
+            self.skipTest(f"Colab examples directory not found at {self.colab_examples_dir}")
+
+        # Create output directory for MVSX files
+        output_dir = os.path.join(self.test_dir, "colab_mvsx_output")
+        os.makedirs(output_dir, exist_ok=True)
+
+        # Get list of MVSJ files in colab_examples directory
+        mvsj_files = [f for f in os.listdir(self.colab_examples_dir) if f.endswith('.mvsj')]
+        self.assertGreater(len(mvsj_files), 0, "No MVSJ files found in colab_examples directory")
+
+        logger.info(f"Found {len(mvsj_files)} MVSJ files in colab_examples directory")
+
+        # Process each MVSJ file
+        for mvsj_filename in mvsj_files:
+            logger.info(f"Processing {mvsj_filename}")
+
+            try:
+                mvsj_path = os.path.join(self.colab_examples_dir, mvsj_filename)
+                mvsx_filename = os.path.splitext(mvsj_filename)[0] + ".mvsx"
+                mvsx_path = os.path.join(output_dir, mvsx_filename)
+
+                # Create MVSX archive
+                result = mvsj_to_mvsx(
+                    mvsj_path,
+                    mvsx_path,
+                    download_external=True,
+                    logger=logger
+                )
+
+                # Check that conversion was successful
+                self.assertTrue(result, f"Failed to convert {mvsj_filename} to MVSX")
+                self.assertTrue(os.path.exists(mvsx_path), f"MVSX file {mvsx_path} not created")
+
+                # Examine MVSX contents
+                with zipfile.ZipFile(mvsx_path, 'r') as z:
+                    files = z.namelist()
+                    self.assertIn("index.mvsj", files, f"index.mvsj not found in {mvsx_filename}")
+
+                    # Check that the index.mvsj file is valid JSON
+                    with z.open("index.mvsj") as f:
+                        try:
+                            mvsj_content = json.loads(f.read().decode('utf-8'))
+                            self.assertIsInstance(mvsj_content, dict, f"index.mvsj in {mvsx_filename} is not a valid JSON object")
+
+                            # Check if it has metadata
+                            if "metadata" in mvsj_content:
+                                self.assertIsInstance(
+                                    mvsj_content["metadata"],
+                                    dict,
+                                    f"metadata in {mvsx_filename} is not a valid JSON object"
+                                )
+                        except json.JSONDecodeError as e:
+                            self.fail(f"index.mvsj in {mvsx_filename} contains invalid JSON: {e}")
+                        except UnicodeDecodeError as e:
+                            self.fail(f"index.mvsj in {mvsx_filename} contains invalid unicode characters: {e}")
+
+                # Extract the MVSX and verify
+                extract_dir = os.path.join(output_dir, os.path.splitext(mvsj_filename)[0])
+                os.makedirs(extract_dir, exist_ok=True)
+
+                index_path = extract_mvsx(
+                    mvsx_path,
+                    extract_dir,
+                    logger=logger
+                )
+
+                # Check that extraction was successful
+                self.assertIsNotNone(index_path, f"Failed to extract {mvsx_filename}")
+                self.assertTrue(os.path.exists(index_path), f"index.mvsj not found in extracted {mvsx_filename}")
+
+                # Load and verify the extracted MVSJ content
+                with open(index_path, 'r', encoding='utf-8') as f:
+                    try:
+                        extracted_mvsj = json.load(f)
+                        self.assertIsInstance(extracted_mvsj, dict, f"Extracted index.mvsj from {mvsx_filename} is not a valid JSON object")
+                    except json.JSONDecodeError as e:
+                        self.fail(f"Extracted index.mvsj from {mvsx_filename} contains invalid JSON: {e}")
+                    except UnicodeDecodeError as e:
+                        self.fail(f"Failed to decode {index_path} as UTF-8: {e}")
+
+            except Exception as e:
+                logger.error(f"Error processing {mvsj_filename}: {e}")
+                self.fail(f"Unexpected error processing {mvsj_filename}: {type(e).__name__}: {e}")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test-data/colab_examples/components.mvsj
+++ b/test-data/colab_examples/components.mvsj
@@ -1,0 +1,190 @@
+{
+  "kind": "single",
+  "root": {
+    "kind": "root",
+    "children": [
+      {
+        "kind": "download",
+        "params": {
+          "url": "https://files.wwpdb.org/download/1c0a.cif"
+        },
+        "children": [
+          {
+            "kind": "parse",
+            "params": {
+              "format": "mmcif"
+            },
+            "children": [
+              {
+                "kind": "structure",
+                "params": {
+                  "type": "assembly"
+                },
+                "children": [
+                  {
+                    "kind": "component",
+                    "params": {
+                      "selector": "protein"
+                    },
+                    "children": [
+                      {
+                        "kind": "representation",
+                        "params": {
+                          "type": "cartoon"
+                        },
+                        "children": [
+                          {
+                            "kind": "color",
+                            "params": {
+                              "color": "#e19039"
+                            }
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "component",
+                    "params": {
+                      "selector": "nucleic"
+                    },
+                    "children": [
+                      {
+                        "kind": "representation",
+                        "params": {
+                          "type": "cartoon"
+                        },
+                        "children": [
+                          {
+                            "kind": "color",
+                            "params": {
+                              "color": "#4b7fcc"
+                            }
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "component",
+                    "params": {
+                      "selector": {
+                        "label_asym_id": "E"
+                      }
+                    },
+                    "children": [
+                      {
+                        "kind": "representation",
+                        "params": {
+                          "type": "ball_and_stick"
+                        },
+                        "children": [
+                          {
+                            "kind": "color",
+                            "params": {
+                              "color": "#229954"
+                            }
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "component",
+                    "params": {
+                      "selector": {
+                        "label_asym_id": "B",
+                        "label_seq_id": 217
+                      }
+                    },
+                    "children": [
+                      {
+                        "kind": "representation",
+                        "params": {
+                          "type": "ball_and_stick"
+                        },
+                        "children": [
+                          {
+                            "kind": "color",
+                            "params": {
+                              "color": "#ff0000"
+                            }
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "label",
+                        "params": {
+                          "text": "aaRS Class II Signature"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "component",
+                    "params": {
+                      "selector": {
+                        "label_asym_id": "B",
+                        "label_seq_id": 537
+                      }
+                    },
+                    "children": [
+                      {
+                        "kind": "representation",
+                        "params": {
+                          "type": "ball_and_stick"
+                        },
+                        "children": [
+                          {
+                            "kind": "color",
+                            "params": {
+                              "color": "#ff0000"
+                            }
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "label",
+                        "params": {
+                          "text": "aaRS Class II Signature"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "component",
+                    "params": {
+                      "selector": [
+                        {
+                          "label_asym_id": "E"
+                        },
+                        {
+                          "label_asym_id": "B",
+                          "label_seq_id": 217
+                        },
+                        {
+                          "label_asym_id": "B",
+                          "label_seq_id": 537
+                        }
+                      ]
+                    },
+                    "children": [
+                      {
+                        "kind": "focus",
+                        "params": {}
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "metadata": {
+    "timestamp": "2025-03-18T18:25:07.419823+00:00",
+    "version": "1.3"
+  }
+}

--- a/test-data/colab_examples/geometrical.mvsj
+++ b/test-data/colab_examples/geometrical.mvsj
@@ -1,0 +1,193 @@
+{
+  "kind": "single",
+  "root": {
+    "kind": "root",
+    "children": [
+      {
+        "kind": "primitives",
+        "params": {
+          "opacity": 0.66
+        },
+        "children": [
+          {
+            "kind": "primitive",
+            "params": {
+              "kind": "ellipse",
+              "center": [
+                1,
+                1,
+                1
+              ],
+              "major_axis": [
+                1.5,
+                0,
+                0
+              ],
+              "minor_axis": [
+                0,
+                2,
+                0
+              ],
+              "theta_start": 0,
+              "theta_end": 1.5707963267948966,
+              "color": "red",
+              "tooltip": "XY"
+            }
+          },
+          {
+            "kind": "primitive",
+            "params": {
+              "kind": "ellipse",
+              "center": [
+                1,
+                1,
+                1
+              ],
+              "major_axis_endpoint": [
+                2.5,
+                1,
+                1
+              ],
+              "minor_axis_endpoint": [
+                1,
+                1,
+                2
+              ],
+              "theta_start": 0,
+              "theta_end": 1.5707963267948966,
+              "color": "green",
+              "tooltip": "XZ"
+            }
+          },
+          {
+            "kind": "primitive",
+            "params": {
+              "kind": "ellipse",
+              "center": [
+                1,
+                1,
+                1
+              ],
+              "major_axis": [
+                0,
+                10,
+                0
+              ],
+              "minor_axis": [
+                0,
+                0,
+                1
+              ],
+              "radius_major": 2,
+              "radius_minor": 1,
+              "theta_start": 0,
+              "theta_end": 1.5707963267948966,
+              "color": "blue",
+              "tooltip": "YZ"
+            }
+          },
+          {
+            "kind": "primitive",
+            "params": {
+              "kind": "arrow",
+              "start": [
+                1,
+                1,
+                1
+              ],
+              "end": [
+                2.5,
+                1,
+                1
+              ],
+              "length": 1.7,
+              "show_end_cap": true,
+              "tube_radius": 0.05,
+              "color": "#ffff00",
+              "tooltip": "X"
+            }
+          },
+          {
+            "kind": "primitive",
+            "params": {
+              "kind": "arrow",
+              "start": [
+                1,
+                1,
+                1
+              ],
+              "direction": [
+                0,
+                2.2,
+                0
+              ],
+              "show_end_cap": true,
+              "tube_radius": 0.05,
+              "color": "#ff00ff",
+              "tooltip": "Y"
+            }
+          },
+          {
+            "kind": "primitive",
+            "params": {
+              "kind": "arrow",
+              "start": [
+                1,
+                1,
+                2.2
+              ],
+              "end": [
+                1,
+                1,
+                1
+              ],
+              "show_start_cap": true,
+              "tube_radius": 0.05,
+              "color": "#00ffff",
+              "tooltip": "Z"
+            }
+          }
+        ]
+      },
+      {
+        "kind": "primitives",
+        "params": {
+          "opacity": 0.33
+        },
+        "children": [
+          {
+            "kind": "primitive",
+            "params": {
+              "kind": "ellipsoid",
+              "center": [
+                1,
+                1,
+                1
+              ],
+              "major_axis": [
+                1,
+                0,
+                0
+              ],
+              "minor_axis": [
+                0,
+                1,
+                0
+              ],
+              "radius": [
+                1.5,
+                2,
+                1
+              ],
+              "color": "#cccccc"
+            }
+          }
+        ]
+      }
+    ]
+  },
+  "metadata": {
+    "timestamp": "2025-04-07T06:55:52.442727+00:00",
+    "version": "1.3"
+  }
+}

--- a/test-data/colab_examples/labels.mvsj
+++ b/test-data/colab_examples/labels.mvsj
@@ -1,0 +1,83 @@
+{
+  "kind": "single",
+  "root": {
+    "kind": "root",
+    "children": [
+      {
+        "kind": "download",
+        "params": {
+          "url": "https://files.wwpdb.org/download/1LAP.cif"
+        },
+        "children": [
+          {
+            "kind": "parse",
+            "params": {
+              "format": "mmcif"
+            },
+            "children": [
+              {
+                "kind": "structure",
+                "params": {
+                  "type": "model"
+                },
+                "children": [
+                  {
+                    "kind": "component",
+                    "params": {
+                      "selector": "all"
+                    },
+                    "children": [
+                      {
+                        "kind": "representation",
+                        "params": {
+                          "type": "cartoon"
+                        },
+                        "children": [
+                          {
+                            "kind": "color",
+                            "params": {
+                              "selector": {
+                                "label_asym_id": "A",
+                                "label_seq_id": 120
+                              },
+                              "color": "red"
+                            }
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "component",
+                    "params": {
+                      "selector": {
+                        "label_asym_id": "A",
+                        "label_seq_id": 120
+                      }
+                    },
+                    "children": [
+                      {
+                        "kind": "label",
+                        "params": {
+                          "text": "ALA 120 A: My Label"
+                        }
+                      },
+                      {
+                        "kind": "focus",
+                        "params": {}
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "metadata": {
+    "timestamp": "2025-03-18T18:25:04.680547+00:00",
+    "version": "1.3"
+  }
+}

--- a/test-data/colab_examples/minimal.mvsj
+++ b/test-data/colab_examples/minimal.mvsj
@@ -1,0 +1,58 @@
+{
+  "kind": "single",
+  "root": {
+    "kind": "root",
+    "children": [
+      {
+        "kind": "download",
+        "params": {
+          "url": "https://files.wwpdb.org/download/1cbs.cif"
+        },
+        "children": [
+          {
+            "kind": "parse",
+            "params": {
+              "format": "mmcif"
+            },
+            "children": [
+              {
+                "kind": "structure",
+                "params": {
+                  "type": "model"
+                },
+                "children": [
+                  {
+                    "kind": "component",
+                    "params": {
+                      "selector": "all"
+                    },
+                    "children": [
+                      {
+                        "kind": "representation",
+                        "params": {
+                          "type": "cartoon"
+                        },
+                        "children": [
+                          {
+                            "kind": "color",
+                            "params": {
+                              "color": "blue"
+                            }
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "metadata": {
+    "timestamp": "2025-03-19T21:14:37.291740+00:00",
+    "version": "1.3"
+  }
+}

--- a/test-data/colab_examples/superimpose.mvsj
+++ b/test-data/colab_examples/superimpose.mvsj
@@ -1,0 +1,125 @@
+{
+  "kind": "single",
+  "root": {
+    "kind": "root",
+    "children": [
+      {
+        "kind": "download",
+        "params": {
+          "url": "https://files.wwpdb.org/download/4hhb.cif"
+        },
+        "children": [
+          {
+            "kind": "parse",
+            "params": {
+              "format": "mmcif"
+            },
+            "children": [
+              {
+                "kind": "structure",
+                "params": {
+                  "type": "model"
+                },
+                "children": [
+                  {
+                    "kind": "component",
+                    "params": {
+                      "selector": "all"
+                    },
+                    "children": [
+                      {
+                        "kind": "representation",
+                        "params": {
+                          "type": "cartoon"
+                        },
+                        "children": [
+                          {
+                            "kind": "color",
+                            "params": {
+                              "color": "red"
+                            }
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "kind": "download",
+        "params": {
+          "url": "https://files.wwpdb.org/download/1oj6.cif"
+        },
+        "children": [
+          {
+            "kind": "parse",
+            "params": {
+              "format": "mmcif"
+            },
+            "children": [
+              {
+                "kind": "structure",
+                "params": {
+                  "type": "model"
+                },
+                "children": [
+                  {
+                    "kind": "transform",
+                    "params": {
+                      "rotation": [
+                        -0.7202161,
+                        -0.33009904,
+                        -0.61018308,
+                        0.36257631,
+                        0.57075962,
+                        -0.73673053,
+                        0.59146191,
+                        -0.75184312,
+                        -0.29138417
+                      ],
+                      "translation": [
+                        -12.54,
+                        46.79,
+                        94.5
+                      ]
+                    }
+                  },
+                  {
+                    "kind": "component",
+                    "params": {
+                      "selector": "all"
+                    },
+                    "children": [
+                      {
+                        "kind": "representation",
+                        "params": {
+                          "type": "cartoon"
+                        },
+                        "children": [
+                          {
+                            "kind": "color",
+                            "params": {
+                              "color": "blue"
+                            }
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "metadata": {
+    "timestamp": "2025-04-07T06:55:52.423833+00:00",
+    "version": "1.3"
+  }
+}

--- a/test-data/colab_examples/volumetric.mvsj
+++ b/test-data/colab_examples/volumetric.mvsj
@@ -1,0 +1,208 @@
+{
+  "kind": "multiple",
+  "metadata": {
+    "description": "1tqn + Volume Server",
+    "timestamp": "2025-04-07T06:55:52.458616+00:00",
+    "version": "1.3"
+  },
+  "snapshots": [
+    {
+      "root": {
+        "kind": "root",
+        "children": [
+          {
+            "kind": "download",
+            "params": {
+              "url": "https://files.wwpdb.org/download/1TQN.cif"
+            },
+            "children": [
+              {
+                "kind": "parse",
+                "params": {
+                  "format": "mmcif"
+                },
+                "children": [
+                  {
+                    "kind": "structure",
+                    "params": {
+                      "type": "model"
+                    },
+                    "children": [
+                      {
+                        "kind": "component",
+                        "params": {
+                          "selector": "polymer"
+                        },
+                        "children": [
+                          {
+                            "kind": "representation",
+                            "params": {
+                              "type": "cartoon"
+                            },
+                            "children": [
+                              {
+                                "kind": "color",
+                                "params": {
+                                  "color": "white"
+                                }
+                              }
+                            ]
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "component",
+                        "params": {
+                          "selector": "ligand"
+                        },
+                        "children": [
+                          {
+                            "kind": "representation",
+                            "params": {
+                              "type": "ball_and_stick"
+                            },
+                            "children": [
+                              {
+                                "kind": "color",
+                                "params": {},
+                                "custom": {
+                                  "molstar_color_theme_name": "element-symbol"
+                                }
+                              }
+                            ]
+                          },
+                          {
+                            "kind": "focus",
+                            "params": {
+                              "direction": [
+                                -28.47,
+                                -17.66,
+                                -16.32
+                              ],
+                              "up": [
+                                0.98,
+                                -0.19,
+                                0
+                              ],
+                              "radius": 14,
+                              "radius_extent": 5
+                            }
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "kind": "download",
+            "params": {
+              "url": "https://www.ebi.ac.uk/pdbe/densities/x-ray/1tqn/box/-22.367,-33.367,-21.634/-7.106,-10.042,-0.937?detail=3"
+            },
+            "children": [
+              {
+                "kind": "parse",
+                "params": {
+                  "format": "bcif"
+                },
+                "children": [
+                  {
+                    "kind": "volume",
+                    "params": {
+                      "channel_id": "2FO-FC"
+                    },
+                    "children": [
+                      {
+                        "kind": "volume_representation",
+                        "params": {
+                          "type": "isosurface",
+                          "relative_isovalue": 1.5,
+                          "show_wireframe": true,
+                          "show_faces": false
+                        },
+                        "children": [
+                          {
+                            "kind": "color",
+                            "params": {
+                              "color": "blue"
+                            }
+                          },
+                          {
+                            "kind": "opacity",
+                            "params": {
+                              "opacity": 0.3
+                            }
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "kind": "volume",
+                    "params": {
+                      "channel_id": "FO-FC"
+                    },
+                    "children": [
+                      {
+                        "kind": "volume_representation",
+                        "params": {
+                          "type": "isosurface",
+                          "relative_isovalue": 3,
+                          "show_wireframe": true
+                        },
+                        "children": [
+                          {
+                            "kind": "color",
+                            "params": {
+                              "color": "green"
+                            }
+                          },
+                          {
+                            "kind": "opacity",
+                            "params": {
+                              "opacity": 0.3
+                            }
+                          }
+                        ]
+                      },
+                      {
+                        "kind": "volume_representation",
+                        "params": {
+                          "type": "isosurface",
+                          "relative_isovalue": -3,
+                          "show_wireframe": true
+                        },
+                        "children": [
+                          {
+                            "kind": "color",
+                            "params": {
+                              "color": "red"
+                            }
+                          },
+                          {
+                            "kind": "opacity",
+                            "params": {
+                              "opacity": 0.3
+                            }
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "metadata": {
+        "title": "1tqn",
+        "description": "\n### 1tqn with ligand and electron density map\n- 2FO-FC at 1.5σ, blue\n- FO-FC (positive) at 3σ, green\n- FO-FC (negative) at -3σ, red\n",
+        "key": "8e0bb47e-a081-4d39-97d9-67589bcc2c85",
+        "linger_duration_ms": 1000
+      }
+    }
+  ]
+}


### PR DESCRIPTION
# MVSX Support: Offline Molecular Visualization with Self-Contained Archives

## Overview
Adds `MVSJ to MVSX` functionality to package MVSJ files with all their referenced resources into a single ZIP archive for offline use.

## Features
- URI reference detection and resolution
- External resource downloading
- Automatic MVSJ path updating
- Archive creation and extraction

## Implementation (in `molviewspec/api/utils.py`)
- `find_uri_references()`: Identifies URL references in MVSJ data
- `update_uri_references()`: Updates paths to use local references
- `mvsj_to_mvsx()`: Creates MVSX archives with external resources
- `extract_mvsx()`: Extracts archives for use

## Testing
- Unit tests for single/complex/multi-state MVSJ files (`molviewspec/test_mvsj_to_mvsx.py`)
- Mock HTTP handling for testing download failures
- Real-world tests with Colaboratory examples
- Interactive `/testing/mvsj_to_mvsx` API endpoint

## Examples

### Endpoint in `examples.py`
`http://localhost:9000/api/v1/examples/testing/mvsj_to_mvsx?id=1cbs&download=true`
> downloads 1cbs.mvsx
`unzip 1cbs.mvsx` - unzips `index.mvsj` and `1cbs.cif`

### Use within a python script
```
cd molviewspec
python -c "import logging; logging.basicConfig(level=logging.INFO); logger = logging.getLogger('mvsx_demo'); from molviewspec.utils import mvsj_to_mvsx; mvsj_to_mvsx('../test-data/colab_examples/minimal.mvsj', 'minimal.mvsx', logger=logger)"
```
Output:
```
INFO:mvsx_demo:Creating MVSX from ../test-data/colab_examples/minimal.mvsj to minimal.mvsx
INFO:mvsx_demo:Downloading external resource: https://files.wwpdb.org/download/1cbs.cif
INFO:mvsx_demo:MVSX archive created successfully: minimal.mvsx
```

`unzip minimal.mvsx` - unzips `index.mvsj` and `1cbs.cif`
```	
$ diff index.mvsj ../test-data/colab_examples/minimal.mvsj
9c9
<           "url": "1cbs.cif"
---
>           "url": "https://files.wwpdb.org/download/1cbs.cif"
```
## Considerations:
- Downloaded colab examples into `test-data/colab_examples`, these are used in `test_mvsj_to_mvsx.py`. They add additional robustness to the test case scenarios, but not sure if we want to store them downloaded like this.
- The new feature is stored in `molviewspec/api/utils.py`, currently it dominates the file by the amount of code. Maybe a dedicated file for the feature would be more suitable?