### PR TITLE
Fix: box primitive tooltip was missing default value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Change Log
 All notable changes to this project will be documented in this file, following the suggestions of [Keep a CHANGELOG](http://keepachangelog.com/). This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+- Fix missing tooltip default value for `BoxParams`
+
 ## [v1.4.0] - 2025-04-09
 
 - Add `auth/label_comp_id` to `ComponentExpression`

--- a/README.md
+++ b/README.md
@@ -269,6 +269,7 @@ Will call all API endpoint that can be called without arguments.
 ```
 cd molviewspec
 python test_mvsj_to_mvsx.py
+python test_serialization.py
 ```
 
 ### Testing everything

--- a/molviewspec/molviewspec/nodes.py
+++ b/molviewspec/molviewspec/nodes.py
@@ -988,7 +988,7 @@ class BoxParams(BaseModel):
     edge_radius: Optional[float] = Field(None, description="Radius of the box edges. In angstroms.")
     edge_color: Optional[ColorT] = Field(None, description="Color of the edges.")
 
-    tooltip: Optional[str] = Field(description="Tooltip to show when hovering on the box.")
+    tooltip: Optional[str] = Field(None, description="Tooltip to show when hovering on the box.")
 
     # NOTE: Possible future extensions:
     # - support box orientation

--- a/molviewspec/test_serialization.py
+++ b/molviewspec/test_serialization.py
@@ -1,40 +1,32 @@
-"""Test module for converting builder to msvj state."""
+"""Test module builder serialization."""
 
-import json
 import logging
-import os
-import shutil
-import tempfile
 import unittest
-import urllib.request
-import zipfile
-from urllib.parse import urlparse
 
 from molviewspec.builder import create_builder
 
 # Set up logging for tests
-logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s")
+logging.basicConfig(
+    level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+)
 logger = logging.getLogger(__name__)
 
 
-
 class TestSerialization(unittest.TestCase):
-
     def test_box(self):
         """Test box serialization."""
         builder = create_builder()
         builder.primitives().box(
             center=(0.5, 0.5, 1.0),
-            extent=(0.5, 0.5, 2.),  
+            extent=(0.5, 0.5, 2.0),
             show_faces=True,
             face_color="blue",
             show_edges=False,
         )
         state = builder.get_state()
-        
+
         self.assertIn("primitives", state)
         self.assertIn("box", state)
-
 
 
 if __name__ == "__main__":

--- a/molviewspec/test_serialization.py
+++ b/molviewspec/test_serialization.py
@@ -1,0 +1,41 @@
+"""Test module for converting builder to msvj state."""
+
+import json
+import logging
+import os
+import shutil
+import tempfile
+import unittest
+import urllib.request
+import zipfile
+from urllib.parse import urlparse
+
+from molviewspec.builder import create_builder
+
+# Set up logging for tests
+logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s")
+logger = logging.getLogger(__name__)
+
+
+
+class TestSerialization(unittest.TestCase):
+
+    def test_box(self):
+        """Test box serialization."""
+        builder = create_builder()
+        builder.primitives().box(
+            center=(0.5, 0.5, 1.0),
+            extent=(0.5, 0.5, 2.),  
+            show_faces=True,
+            face_color="blue",
+            show_edges=False,
+        )
+        state = builder.get_state()
+        
+        self.assertIn("primitives", state)
+        self.assertIn("box", state)
+
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- Thank you for contributing to mol-view-spec -->

# Description

- Adds missing default value for BoxParams tooltip
- Add unit test which would fail without the fix

## Actions

- [x] Added description of changes to the `[Unreleased]` section of `CHANGELOG.md`
- [ ] (Optional but encouraged) Added example(s) for new feature(s) in this PR to `app/api/examples.py`