### PR TITLE
Add missing import for mvsj_to_mvsx in package init

### DIFF
--- a/molviewspec/molviewspec/__init__.py
+++ b/molviewspec/molviewspec/__init__.py
@@ -13,3 +13,4 @@ from molviewspec.nodes import (
     States,
     validate_state_tree,
 )
+from molviewspec.mvsx_converter import mvsj_to_mvsx


### PR DESCRIPTION
<!-- Thank you for contributing to mol-view-spec -->

# Description
This PR fixes a missing import from #54  where `mvsj_to_mvsx` was not exposed in `__init__.py`.
As a result, it currently can't be accessed via the top-level `molviewspec` module:
```
>>> mvs.__version__
'1.4.0'
>>> import molviewspec as mvs
>>> 'mvsj_to_mvsx' in dir(mvs)
False
```

This change adds the missing import:
```
>>> import molviewspec as mvs
>>> 'mvsj_to_mvsx' in dir(mvs)
True
>>> from molviewspec import mvsj_to_mvsx  # ✅ works
```
Now the function is accessible as intended.