### PR TITLE
Clipping support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file, following t
 - Add `vector_radius` param for primitive `angle_measurement`
 - Add `field_remapping` param for `*_from_*` nodes
 - Add `palette` param for `color_from_*` nodes
+- Add `clip` node support for structure and volume representations
 
 ## [v1.6.0] - 2025-04-22
 

--- a/molviewspec/app/api/examples.py
+++ b/molviewspec/app/api/examples.py
@@ -1095,7 +1095,8 @@ async def minimal_clip_example() -> MVSResponse:
     (
         model.component(selector="polymer")
         .representation()
-        .clip(type="sphere", position=(22.03, 25.62, 21.05), scale=(20, 20, 20))
+        .clip(type="sphere", center=(22.03, 25.62, 21.05), radius=20)
+        .clip(type="plane", normal=(1, 0, 0), point=(22.03, 25.62, 21.05))
     )
     (model.component(selector="ligand").representation(type="ball_and_stick").color(color="red"))
     return JSONResponse(builder.get_state().to_dict())

--- a/molviewspec/app/api/examples.py
+++ b/molviewspec/app/api/examples.py
@@ -1095,10 +1095,15 @@ async def minimal_clip_example() -> MVSResponse:
     (
         model.component(selector="polymer")
         .representation()
-        .clip(type="sphere", center=(22.03, 25.62, 21.05), radius=20)
+        .clip(type="sphere", center=(22.03, 25.62, 21.05), radius=10)
         .clip(type="plane", normal=(1, 0, 0), point=(22.03, 25.62, 21.05))
     )
-    (model.component(selector="ligand").representation(type="ball_and_stick").color(color="red"))
+    (
+        model.component(selector="ligand")
+        .representation(type="ball_and_stick")
+        .color(color="red")
+        .clip(type="box", center=(22.03, 25.62, 21.05), size=(1, 1, 1))
+    )
     return JSONResponse(builder.get_state().to_dict())
 
 

--- a/molviewspec/app/api/examples.py
+++ b/molviewspec/app/api/examples.py
@@ -1084,6 +1084,23 @@ async def volume_server_map_example() -> MVSResponse:
     )
 
 
+@router.get("/clip/minimal")
+async def minimal_clip_example() -> MVSResponse:
+    """
+    Minimal clipping example
+    """
+    builder = create_builder()
+    model = builder.download(url=_url_for_mmcif("1cbs")).parse(format="mmcif").model_structure()
+
+    (
+        model.component(selector="polymer")
+        .representation()
+        .clip(type="sphere", position=(22.03, 25.62, 21.05), scale=(20, 20, 20))
+    )
+    (model.component(selector="ligand").representation(type="ball_and_stick").color(color="red"))
+    return JSONResponse(builder.get_state().to_dict())
+
+
 ##############################################################################
 # meta endpoints
 

--- a/molviewspec/molviewspec/builder.py
+++ b/molviewspec/molviewspec/builder.py
@@ -228,12 +228,12 @@ class _ClipMixin(_BuilderProtocol):
         """
         Clip this representation. Multiple clip objects can be defined.
         :param type: type of clipping region, i.e. box, sphere, cylinder, plane, or infinite cone
-        :param position: position of the clip plane
+        :param position: position of the clipping region
         :param rotation_axis: axis of rotation around which the clip plane is rotated (default: (1, 0, 0))
         :param rotation_angle: angle in radians by which the clip plane is rotated around the `rotation_axis` (default: 0)
-        :param scale: scale factor for the clip plane (default: (1, 1, 1))
-        :param transform: transformation matrix to apply to the clip plane (default: None)
-        :param invert: whether to invert the clip object (default: False)
+        :param scale: scale factor for the clipping region (default: (1, 1, 1))
+        :param transform: transformation matrix to apply to the clipping region (default: None)
+        :param invert: whether to invert the clip object, e.g., clip outside a sphere (default: False)
         :param variant: whether to clip the object or pixel space (default: "pixel")
         :param custom: optional, custom data to attach to this node
         :param ref: optional, reference that can be used to access this node

--- a/molviewspec/molviewspec/builder.py
+++ b/molviewspec/molviewspec/builder.py
@@ -19,6 +19,8 @@ from molviewspec.nodes import (
     BoxParams,
     CameraParams,
     CanvasParams,
+    ClipParams,
+    ClipTypeT,
     ColorFromSourceParams,
     ColorFromUriParams,
     ColorInlineParams,
@@ -195,6 +197,37 @@ class _FocusMixin(_BuilderProtocol):
         """
         params = make_params(FocusInlineParams, locals())
         node = Node(kind="focus", params=params)
+        self._add_child(node)
+        return self
+
+
+class _ClipMixin(_BuilderProtocol):
+    def clip(
+        self,
+        *,
+        type: ClipTypeT,
+        position: Vec3,
+        rotation_axis: Vec3 | None = None,
+        rotation_angle: float | None = None,
+        scale: Vec3 | None = None,
+        transform: Mat4 | None = None,
+        invert: bool = False,
+        variant: Literal["object", "pixel"] | None = None,
+    ) -> Self:
+        """
+        Clip this representation. Multiple clip objects can be defined.
+        :param type: type of clipping region, i.e. box, sphere, cylinder, plane, or infinite cone
+        :param position: position of the clip plane
+        :param rotation_axis: axis of rotation around which the clip plane is rotated (default: (1, 0, 0))
+        :param rotation_angle: angle in radians by which the clip plane is rotated around the `rotation_axis` (default: 0)
+        :param scale: scale factor for the clip plane (default: (1, 1, 1))
+        :param transform: transformation matrix to apply to the clip plane (default: None)
+        :param invert: whether to invert the clip object (default: False)
+        :param variant: whether to clip the object or pixel space (default: "pixel")
+        :return: this builder
+        """
+        params = make_params(ClipParams, locals())
+        node = Node(kind="clip", params=params)
         self._add_child(node)
         return self
 
@@ -941,7 +974,7 @@ class Component(_Base, _FocusMixin):
         return self
 
 
-class Representation(_Base):
+class Representation(_Base, _ClipMixin):
     """
     Builder step with operations relating to particular representations.
     """
@@ -1111,7 +1144,7 @@ class Volume(_Base, _FocusMixin):
         return VolumeRepresentation(node=node, root=self._root)
 
 
-class VolumeRepresentation(_Base, _FocusMixin):
+class VolumeRepresentation(_Base, _FocusMixin, _ClipMixin):
     """
     Builder step with operations relating to particular representations.
     """

--- a/molviewspec/molviewspec/builder.py
+++ b/molviewspec/molviewspec/builder.py
@@ -140,6 +140,8 @@ class _PrimitivesMixin(_BuilderProtocol):
         opacity: float | None = None,
         label_opacity: float | None = None,
         instances: list[Mat4[float]] | None = None,
+        custom: CustomT = None,
+        ref: RefT = None,
     ) -> Primitives:
         """
         Allows the definition of a (group of) geometric primitives. You can add any number of primitives and then assign
@@ -150,6 +152,9 @@ class _PrimitivesMixin(_BuilderProtocol):
         :param opacity: opacity of primitive geometry in this group (default: 1)
         :param label_opacity: opacity of primitive labels in this group (default: 1)
         :param instances: instances of this primitive group defined as 4x4 column major (j * 4 + i indexing) transformation matrices
+        :param custom: optional, custom data to attach to this node
+        :param ref: optional, reference that can be used to access this node
+        :return: primitives builder node
         """
         params = make_params(PrimitivesParams, locals())
         node = Node(kind="primitives", params=params)
@@ -185,6 +190,8 @@ class _FocusMixin(_BuilderProtocol):
         radius: float | None = None,
         radius_factor: float | None = None,
         radius_extent: float | None = None,
+        custom: CustomT = None,
+        ref: RefT = None,
     ) -> Self:
         """
         Focus on this structure or component.
@@ -193,6 +200,8 @@ class _FocusMixin(_BuilderProtocol):
         :param radius: radius of the focused sphere (overrides `radius_factor` and `radius_extra`)
         :param radius_factor: radius of the focused sphere relative to the radius of parent component (default: 1); focused radius = component_radius * radius_factor + radius_extent
         :param radius_extent: addition to the radius of the focused sphere, if computed from the radius of parent component (default: 0); focused radius = component_radius * radius_factor + radius_extent
+        :param custom: optional, custom data to attach to this node
+        :param ref: optional, reference that can be used to access this node
         :return: this builder
         """
         params = make_params(FocusInlineParams, locals())
@@ -213,6 +222,8 @@ class _ClipMixin(_BuilderProtocol):
         transform: Mat4 | None = None,
         invert: bool = False,
         variant: Literal["object", "pixel"] | None = None,
+        custom: CustomT = None,
+        ref: RefT = None,
     ) -> Self:
         """
         Clip this representation. Multiple clip objects can be defined.
@@ -224,6 +235,8 @@ class _ClipMixin(_BuilderProtocol):
         :param transform: transformation matrix to apply to the clip plane (default: None)
         :param invert: whether to invert the clip object (default: False)
         :param variant: whether to clip the object or pixel space (default: "pixel")
+        :param custom: optional, custom data to attach to this node
+        :param ref: optional, reference that can be used to access this node
         :return: this builder
         """
         params = make_params(ClipParams, locals())

--- a/molviewspec/molviewspec/builder.py
+++ b/molviewspec/molviewspec/builder.py
@@ -42,6 +42,7 @@ from molviewspec.nodes import (
     LabelFromUriParams,
     LabelInlineParams,
     LinesParams,
+    Mat3,
     Mat4,
     MeshParams,
     MolstarWidgetsMixin,
@@ -227,7 +228,7 @@ class _ClipMixin(_BuilderProtocol):
         """
         Add a surface representation for this component.
         :param type: the type of this representation ('plane')
-        :param normal: the normal vector of the clipping plane
+        :param normal: the normal vector of the clipping plane, points towards the clipped region
         :param constant: the distance of the clipping plane from the origin along the normal vector
         :param check_transform: transformation matrix applied to each point before clipping, used for example to clip volumes in the grid/fractional space (default: None)
         :param invert: whether to invert the clip object, e.g., clip outside a sphere (default: False)
@@ -271,8 +272,7 @@ class _ClipMixin(_BuilderProtocol):
         *,
         type: Literal["box"],
         center: Vec3[float],
-        rotation: Vec3[float] | None = None,
-        translation: Vec3[float] | None = None,
+        rotation: Mat3[float] | None = None,
         size: Vec3[float] | None = None,
         check_transform: Mat4 | None = None,
         invert: bool = False,
@@ -285,9 +285,8 @@ class _ClipMixin(_BuilderProtocol):
         :param type: the type of this representation ('plane')
         :param center: the center of the clipping box
         :param rotation: 9d vector describing the rotation, in column major (j * 3 + i indexing) format, this is equivalent to Fortran-order in numpy, to be multiplied from the left (default: identity matrix)
-        :param translation: 3d vector describing the translation (default: (0, 0, 0))
         :param size: 3d vector describing the box size (default: (1, 1, 1))
-        :param point_transform: transformation matrix applied to each point before clipping, used for example to clip volumes in the grid/fractional space (default: None)
+        :param check_transform: transformation matrix applied to each point before clipping, used for example to clip volumes in the grid/fractional space (default: None)
         :param invert: whether to invert the clip object, e.g., clip outside a sphere (default: False)
         :param variant: whether to clip the object or pixel space (default: "pixel")
         :param custom: optional, custom data to attach to this node

--- a/molviewspec/molviewspec/builder.py
+++ b/molviewspec/molviewspec/builder.py
@@ -219,7 +219,7 @@ class _ClipMixin(_BuilderProtocol):
         rotation_axis: Vec3 | None = None,
         rotation_angle: float | None = None,
         scale: Vec3 | None = None,
-        transform: Mat4 | None = None,
+        point_transform: Mat4 | None = None,
         invert: bool = False,
         variant: Literal["object", "pixel"] | None = None,
         custom: CustomT = None,
@@ -232,7 +232,7 @@ class _ClipMixin(_BuilderProtocol):
         :param rotation_axis: axis of rotation around which the clip plane is rotated (default: (1, 0, 0))
         :param rotation_angle: angle in radians by which the clip plane is rotated around the `rotation_axis` (default: 0)
         :param scale: scale factor for the clipping region (default: (1, 1, 1))
-        :param transform: transformation matrix to apply to the clipping region (default: None)
+        :param point_transform: transformation matrix applied to each point before clipping, used for example to clip volumes in the grid/fractional space (default: None)
         :param invert: whether to invert the clip object, e.g., clip outside a sphere (default: False)
         :param variant: whether to clip the object or pixel space (default: "pixel")
         :param custom: optional, custom data to attach to this node

--- a/molviewspec/molviewspec/nodes.py
+++ b/molviewspec/molviewspec/nodes.py
@@ -23,6 +23,7 @@ KindT = Literal[
     "root",
     "camera",
     "canvas",
+    "clip",
     "color",
     "color_from_source",
     "color_from_uri",
@@ -935,7 +936,6 @@ class ContinuousPalette(BaseModel):
     """Color to use for values above the highest checkpoint. 'auto' means color of the lowest checkpoint. (Default behavior is not to color values above the highest checkpoint.)"""
 
 
-
 PaletteT = CategoricalPalette | DiscretePalette | ContinuousPalette
 
 
@@ -1021,6 +1021,26 @@ class VolumeIsoSurfaceParams(RepresentationParams):
 
 
 VolumeRepresentationTypeParams = {get_model_fields(t)["type"].default: t for t in (VolumeIsoSurfaceParams,)}
+
+
+ClipTypeT = Literal["cube", "sphere", "cylinder", "plane", "infinite-cone"]
+
+
+class ClipParams(BaseModel):
+    """
+    Clip node, describing how to clip a representation.
+    """
+
+    type: ClipTypeT = Field(description="Kind of clipping region, i.e. box, sphere, cylinder, plane, or infinite cone.")
+    position: Vec3 = Field((0, 0, 0), description="Position of the clipping region.")
+    rotation_axis: Vec3 = Field((1, 0, 0), description="Axis of rotation of the clipping region. Default is (1, 0, 0).")
+    rotation_angle: float = Field(0.0, description="Rotation angle of the clipping region in radians. Default is 0.")
+    scale: Vec3 = Field((1, 1, 1), description="Scale of the clipping region. Default is (1, 1, 1).")
+    transform: Optional[Mat4] = Field(None, description="Transformation matrix to apply to the clipping region")
+    invert: Optional[bool] = Field(False, description="Inverts the clipping region. Default is false")
+    variant: Literal["object", "pixel"] = Field(
+        "pixel", description="Variant of the clip node, either 'object' or 'pixel'"
+    )
 
 
 class _DataFromUriParams(BaseModel):

--- a/molviewspec/molviewspec/nodes.py
+++ b/molviewspec/molviewspec/nodes.py
@@ -1050,7 +1050,7 @@ class ClipPlaneParams(ClipParamsBase):
 
     type: Literal["plane"] = "plane"
 
-    normal: Vec3 = Field(description="Normal vector of the clipping plane.")
+    normal: Vec3 = Field(description="Normal vector of the clipping plane. Points towards the clipped region.")
     point: Vec3 = Field(description="Point on the clipping plane.")
 
 
@@ -1078,7 +1078,6 @@ class ClipBoxParams(BaseModel):
         None,
         description="9d vector describing the rotation, in a column major (j * 3 + i indexing) format, this is equivalent to Fortran-order in numpy, to be multiplied from the left",
     )
-    translation: Optional[Vec3[float]] = Field(None, description="3d vector describing the translation")
 
 
 ClipTypeParams = {

--- a/molviewspec/molviewspec/nodes.py
+++ b/molviewspec/molviewspec/nodes.py
@@ -1036,7 +1036,7 @@ class ClipParams(BaseModel):
     rotation_axis: Vec3 = Field((1, 0, 0), description="Axis of rotation of the clipping region. Default is (1, 0, 0).")
     rotation_angle: float = Field(0.0, description="Rotation angle of the clipping region in radians. Default is 0.")
     scale: Vec3 = Field((1, 1, 1), description="Scale of the clipping region. Default is (1, 1, 1).")
-    transform: Optional[Mat4] = Field(None, description="Transformation matrix to apply to the clipping region")
+    point_transform: Optional[Mat4] = Field(None, description="Transformation matrix to applied to each point before clipping. For example, can be used to clip volumes in the grid/fractional space. Default is None.")
     invert: Optional[bool] = Field(False, description="Inverts the clipping region. Default is false")
     variant: Literal["object", "pixel"] = Field(
         "pixel", description="Variant of the clip node, either 'object' or 'pixel'"


### PR DESCRIPTION
<!-- Thank you for contributing to mol-view-spec -->

# Description

- [x] `clip` node support for structure and volume representations

## Actions

- [x] Added description of changes to the `[Unreleased]` section of `CHANGELOG.md`
- [x] When adding new features:
  - [x] Added example(s) to `app/api/examples.py`
  - [ ] Added Jupyter Notebook to `test-data/notebooks` with new features
  - [ ] Added MkDocs documentation in `docs`