### PR TITLE
grid-slice volume representation, primitive label tether and background, snapshot_key support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ All notable changes to this project will be documented in this file, following t
 - Add `palette` param for `color_from_*` nodes
 - Add `clip` node support for structure and volume representations
 - Add `instance_id` field to ComponentExpression and MVS annotations
-- Add `grid-slice` volume representation support
+- Add `grid_slice` volume representation support
 - Add `label_show_tether`, `label_tether_length`, `label_attachment`, and `label_background_color` to `PrimitivesParams`
 - Add `snapshot_key` to `PrimitivesParams` that enables navigating to a different snapshot on interaction
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file, following t
 - Add `clip` node support for structure and volume representations
 - Add `grid-slice` volume representation support
 - Add `label_show_tether`, `label_tether_length`, `label_attachment`, and `label_background_color` to `PrimitivesParams`
+- Add `snapshot_key` to `PrimitivesParams` that enables navigating to a different snapshot on interaction
 
 ## [v1.6.0] - 2025-04-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file, following t
 - Add `palette` param for `color_from_*` nodes
 - Add `clip` node support for structure and volume representations
 - Add `grid-slice` volume representation support
+- Add `label_show_tether`, `label_tether_length`, `label_attachment`, and `label_background_color` to `PrimitivesParams`
 
 ## [v1.6.0] - 2025-04-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file, following t
 - Add `field_remapping` param for `*_from_*` nodes
 - Add `palette` param for `color_from_*` nodes
 - Add `clip` node support for structure and volume representations
+- Add `grid-slice` volume representation support
 
 ## [v1.6.0] - 2025-04-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ All notable changes to this project will be documented in this file, following t
 - Add `grid_slice` volume representation support
 - Add `label_show_tether`, `label_tether_length`, `label_attachment`, and `label_background_color` to `PrimitivesParams`
 - Add `snapshot_key` to `PrimitivesParams` that enables navigating to a different snapshot on interaction
+- Add `matrix` field support to `TransformParams`
+- Add `instance` node type
+- Support transforms and instancing on structures, components, and volumes
 
 ## [v1.6.0] - 2025-04-22
 

--- a/molviewspec/app/api/examples.py
+++ b/molviewspec/app/api/examples.py
@@ -1049,17 +1049,17 @@ async def volume_map_example() -> MVSResponse:
     volume = download.parse(format="map").volume()
 
     (
-        volume.representation(type="grid-slice", dimension="x", relative_index=0.5, relative_isovalue=1)
+        volume.representation(type="grid_slice", dimension="x", relative_index=0.5, relative_isovalue=1)
         .color(color="red")
         .opacity(opacity=0.75)
     )
     (
-        volume.representation(type="grid-slice", dimension="y", relative_index=0.5, relative_isovalue=1)
+        volume.representation(type="grid_slice", dimension="y", relative_index=0.5, relative_isovalue=1)
         .color(color="green")
         .opacity(opacity=0.75)
     )
     (
-        volume.representation(type="grid-slice", dimension="z", relative_index=0.5, relative_isovalue=1)
+        volume.representation(type="grid_slice", dimension="z", relative_index=0.5, relative_isovalue=1)
         .color(color="blue")
         .opacity(opacity=0.75)
     )

--- a/molviewspec/app/api/examples.py
+++ b/molviewspec/app/api/examples.py
@@ -2243,6 +2243,28 @@ async def testing_angle_primitive_example() -> MVSResponse:
     return JSONResponse(builder.get_state().to_dict())
 
 
+@router.get("/testing/primitive-labels")
+async def testing_primitive_labels_example() -> MVSResponse:
+    """
+    Return a state showing an angle
+    """
+    builder = create_builder()
+    primitives = builder.primitives(
+        label_attachment="top-right",
+        label_show_tether=True,
+        label_tether_length=2,
+        label_background_color="lightblue",
+    )
+    primitives.sphere(
+        center=(10, 10, 10),
+        radius=1,
+        color="red",
+    )
+    primitives.label(position=(10, 10, 10), text="This is a label", label_offset=2)
+
+    return JSONResponse(builder.get_state().to_dict())
+
+
 @router.get("/testing/primitives/from-uri")
 async def primitives_from_uri_example() -> MVSResponse:
     """

--- a/molviewspec/app/api/examples.py
+++ b/molviewspec/app/api/examples.py
@@ -2247,7 +2247,7 @@ async def testing_angle_primitive_example() -> MVSResponse:
 @router.get("/testing/primitives/labels")
 async def testing_primitive_labels_example() -> MVSResponse:
     """
-    Return a state showing an angle
+    Return a state showing a tethered label attached to a sphere
     """
     builder = create_builder()
     primitives = builder.primitives(
@@ -2280,7 +2280,7 @@ async def primitives_from_uri_example() -> MVSResponse:
 @router.get("/testing/primitives/snapshot-key")
 async def testing_primitive_snapshot_key_example() -> MVSResponse:
     """
-    Return a state showing an angle
+    Return a state showing switching states by interacting with primitives
     """
 
     def _ping_pong(key: str, snapshot_key: str, attachment: LabelAttachmentT, text: str):

--- a/molviewspec/app/api/examples.py
+++ b/molviewspec/app/api/examples.py
@@ -1036,6 +1036,36 @@ async def volume_map_example() -> MVSResponse:
     return JSONResponse(builder.get_state().to_dict())
 
 
+@router.get("/volume/slices")
+async def volume_map_example() -> MVSResponse:
+    """
+    Renders a volume in MAP format
+    """
+
+    builder = create_builder()
+
+    download = builder.download(url="https://www.ebi.ac.uk/pdbe/entry-files/1tqn.ccp4")
+    volume = download.parse(format="map").volume()
+
+    (
+        volume.representation(type="grid-slice", dimension="x", relative_index=0.5, relative_isovalue=1)
+        .color(color="red")
+        .opacity(opacity=0.75)
+    )
+    (
+        volume.representation(type="grid-slice", dimension="y", relative_index=0.5, relative_isovalue=1)
+        .color(color="green")
+        .opacity(opacity=0.75)
+    )
+    (
+        volume.representation(type="grid-slice", dimension="z", relative_index=0.5, relative_isovalue=1)
+        .color(color="blue")
+        .opacity(opacity=0.75)
+    )
+
+    return JSONResponse(builder.get_state().to_dict())
+
+
 @router.get("/volume/volume-server")
 async def volume_server_map_example() -> MVSResponse:
     """

--- a/molviewspec/app/api/examples.py
+++ b/molviewspec/app/api/examples.py
@@ -19,6 +19,7 @@ from molviewspec.nodes import (
     ContinuousPalette,
     DiscretePalette,
     GlobalMetadata,
+    LabelAttachmentT,
     PrimitiveComponentExpressions,
     RepresentationTypeT,
     Snapshot,
@@ -2243,7 +2244,7 @@ async def testing_angle_primitive_example() -> MVSResponse:
     return JSONResponse(builder.get_state().to_dict())
 
 
-@router.get("/testing/primitive-labels")
+@router.get("/testing/primitives/labels")
 async def testing_primitive_labels_example() -> MVSResponse:
     """
     Return a state showing an angle
@@ -2274,6 +2275,38 @@ async def primitives_from_uri_example() -> MVSResponse:
     builder.primitives_from_uri(uri="http://localhost:9000/api/v1/examples/data/basic-primitives")
 
     return JSONResponse(builder.get_state().to_dict())
+
+
+@router.get("/testing/primitives/snapshot-key")
+async def testing_primitive_snapshot_key_example() -> MVSResponse:
+    """
+    Return a state showing an angle
+    """
+
+    def _ping_pong(key: str, snapshot_key: str, attachment: LabelAttachmentT, text: str):
+        builder = create_builder()
+        primitives = builder.primitives(
+            label_attachment=attachment,
+            label_show_tether=True,
+            label_tether_length=2,
+            label_background_color="lightblue",
+            snapshot_key=snapshot_key,
+        )
+        primitives.sphere(
+            center=(10, 10, 10),
+            radius=1,
+            color="red",
+            tooltip="Click to play...",
+        )
+        primitives.label(position=(10, 10, 10), text=text, label_offset=2)
+        return builder.get_snapshot(title=key, key=key)
+
+    snapshots = [
+        _ping_pong("a", "b", "top-right", "Ping"),
+        _ping_pong("b", "a", "bottom-left", "Pong"),
+    ]
+    metadata = GlobalMetadata(description="test")
+    return JSONResponse(States(snapshots=snapshots, metadata=metadata).to_dict())
 
 
 ##############################################################################

--- a/molviewspec/app/api/examples.py
+++ b/molviewspec/app/api/examples.py
@@ -2335,6 +2335,71 @@ async def testing_instance_id_annot_selector() -> MVSResponse:
     return JSONResponse(builder.get_state().to_dict())
 
 
+@router.get("/testing/structure-instancing")
+async def structure_instancing_example() -> MVSResponse:
+    """
+    Instancing of the same structure
+    """
+    builder = create_builder()
+
+    # instantiate top level structure
+    (
+        builder.download(url=_url_for_mmcif("1tqn"))
+        .parse(format="mmcif")
+        .model_structure()
+        .instance(translation=(-50, 0, 0))
+        .instance(translation=(50, 0, 0))
+        .component()
+        .representation()
+        .color(color="red")
+    )
+
+    # instantiate ligand component
+    (
+        builder.download(url=_url_for_mmcif("1cbs"))
+        .parse(format="mmcif")
+        .model_structure()
+        .component(selector="ligand")
+        .instance(translation=(0, 50, 0))
+        .instance(translation=(0, -50, 0))
+        .representation(type="ball_and_stick")
+        .color(color="blue")
+    )
+
+    return JSONResponse(builder.get_state().to_dict())
+
+
+@router.get("/testing/volume-transform-and-instancing")
+async def volume_transform_and_instancing_example() -> MVSResponse:
+    """
+    Example for transforming and instancing volumes
+    """
+
+    builder = create_builder()
+
+    download = builder.download(url="https://www.ebi.ac.uk/pdbe/entry-files/1cbs.ccp4")
+    volume = download.parse(format="map").volume()
+    (
+        volume.instance(translation=(100, 0, 50))
+        .instance(translation=(-100, 0, -50))
+        .representation(type="isosurface", relative_isovalue=1, show_wireframe=True)
+        .color(color="red")
+    )
+
+    download = builder.download(url="https://www.ebi.ac.uk/pdbe/entry-files/1tqn.ccp4")
+    volume = download.parse(format="map").volume()
+    (
+        volume.transform(translation=(0, -100, 0))
+        .representation(type="isosurface", relative_isovalue=1, show_wireframe=True)
+        .color(color="blue")
+    )
+
+    volume = download.parse(format="map").volume()
+    (volume.representation(type="isosurface", relative_isovalue=1, show_wireframe=True).color(color="green"))
+
+    return JSONResponse(builder.get_state().to_dict())
+
+
 @router.get("/testing/angle-primitive")
 async def testing_angle_primitive_example() -> MVSResponse:
     """

--- a/molviewspec/molviewspec/builder.py
+++ b/molviewspec/molviewspec/builder.py
@@ -38,6 +38,7 @@ from molviewspec.nodes import (
     EllipsoidParams,
     FocusInlineParams,
     GlobalMetadata,
+    LabelAttachmentT,
     LabelFromSourceParams,
     LabelFromUriParams,
     LabelInlineParams,
@@ -140,6 +141,10 @@ class _PrimitivesMixin(_BuilderProtocol):
         tooltip: str | None = None,
         opacity: float | None = None,
         label_opacity: float | None = None,
+        label_show_tether: bool | None = None,
+        label_tether_length: float | None = None,
+        label_attachment: LabelAttachmentT | None = None,
+        label_background_color: ColorT | None = None,
         instances: list[Mat4[float]] | None = None,
         custom: CustomT = None,
         ref: RefT = None,
@@ -152,6 +157,10 @@ class _PrimitivesMixin(_BuilderProtocol):
         :param tooltip: default tooltip for primitives in this group (default: no tooltip)
         :param opacity: opacity of primitive geometry in this group (default: 1)
         :param label_opacity: opacity of primitive labels in this group (default: 1)
+        :param label_show_tether: whether to show a tether line between the label and the target (default: False)
+        :param label_tether_length: length of the tether line between the label and the target (default: 1 Angstrom)
+        :param label_attachment: how to attach the label to the target (default: "middle-center")
+        :param label_background_color: background color of the label (default: None/transparent)
         :param instances: instances of this primitive group defined as 4x4 column major (j * 4 + i indexing) transformation matrices
         :param custom: optional, custom data to attach to this node
         :param ref: optional, reference that can be used to access this node

--- a/molviewspec/molviewspec/builder.py
+++ b/molviewspec/molviewspec/builder.py
@@ -145,6 +145,7 @@ class _PrimitivesMixin(_BuilderProtocol):
         label_tether_length: float | None = None,
         label_attachment: LabelAttachmentT | None = None,
         label_background_color: ColorT | None = None,
+        snapshot_key: str | None = None,
         instances: list[Mat4[float]] | None = None,
         custom: CustomT = None,
         ref: RefT = None,
@@ -161,6 +162,7 @@ class _PrimitivesMixin(_BuilderProtocol):
         :param label_tether_length: length of the tether line between the label and the target (default: 1 Angstrom)
         :param label_attachment: how to attach the label to the target (default: "middle-center")
         :param label_background_color: background color of the label (default: None/transparent)
+        :param snapshot_key: load snapshot with the provided key when interacting with this primitives group (default: None)
         :param instances: instances of this primitive group defined as 4x4 column major (j * 4 + i indexing) transformation matrices
         :param custom: optional, custom data to attach to this node
         :param ref: optional, reference that can be used to access this node

--- a/molviewspec/molviewspec/builder.py
+++ b/molviewspec/molviewspec/builder.py
@@ -1205,7 +1205,7 @@ class Volume(_Base, _FocusMixin):
     @overload
     def representation(
         *,
-        type: Literal["grid-slice"],
+        type: Literal["grid_slice"],
         dimension: Literal["x", "y", "z"],
         absolute_index: int | None = None,
         relative_index: float | None = None,
@@ -1216,7 +1216,7 @@ class Volume(_Base, _FocusMixin):
     ) -> VolumeRepresentation:
         """
         Add a grid slice representation for this component.
-        :param type: the type of this representation ('grid-slice')
+        :param type: the type of this representation ('grid_slice')
         :param dimension: the dimension of the slice, one of 'x', 'y', 'z'
         :param absolute_index: absolute index of the slice in the grid
         :param relative_index: relative index of the slice in the grid, 0.0: first slice, 1.0: last slice, overrides `absolute_index`

--- a/molviewspec/molviewspec/builder.py
+++ b/molviewspec/molviewspec/builder.py
@@ -1193,6 +1193,32 @@ class Volume(_Base, _FocusMixin):
 
     @overload
     def representation(
+        *,
+        type: Literal["grid-slice"],
+        dimension: Literal["x", "y", "z"],
+        absolute_index: int | None = None,
+        relative_index: float | None = None,
+        relative_isovalue: float | None = None,
+        absolute_isovalue: float | None = None,
+        custom: CustomT = None,
+        ref: RefT = None,
+    ) -> VolumeRepresentation:
+        """
+        Add a grid slice representation for this component.
+        :param type: the type of this representation ('grid-slice')
+        :param dimension: the dimension of the slice, one of 'x', 'y', 'z'
+        :param absolute_index: absolute index of the slice in the grid
+        :param relative_index: relative index of the slice in the grid, 0.0: first slice, 1.0: last slice, overrides `absolute_index`
+        :param relative_isovalue: relative isovalue to use for the surface
+        :param absolute_isovalue: absolute isovalue to use for the surface, overrides `relative_isovalue`
+        :param custom: optional, custom data to attach to this node
+        :param ref: optional, reference that can be used to access this node
+        :return: a builder that handles operations at representation level
+        """
+        ...
+
+    @overload
+    def representation(
         self, *, type: VolumeRepresentationTypeT = "isosurface", custom: CustomT = None, ref: RefT = None, **kwargs: Any
     ) -> VolumeRepresentation:
         """

--- a/molviewspec/molviewspec/builder.py
+++ b/molviewspec/molviewspec/builder.py
@@ -222,6 +222,91 @@ class _FocusMixin(_BuilderProtocol):
         return self
 
 
+class _TransformMixin(_BuilderProtocol):
+    def transform(
+        self,
+        *,
+        rotation: Sequence[float] | None = None,
+        translation: Sequence[float] | None = None,
+        matrix: Sequence[float] | None = None,
+        custom: CustomT = None,
+        ref: RefT = None,
+    ) -> Self:
+        """
+        Transform the object by applying a rotation matrix and/or translation vector OR a full transform matrix.
+        :param rotation: 9d vector describing the rotation, in column major (j * 3 + i indexing) format, this is equivalent to Fortran-order in numpy, to be multiplied from the left (default: identity matrix)
+        :param translation: 3d vector describing the translation (default: (0, 0, 0))
+        :param matrix: 16d (4x4) vector describing the transformation matrix, in column major (j * 4 + i indexing) format, this is equivalent to Fortran-order in numpy, to be multiplied from the left. Takes precedence over `rotation` and `translation`.
+        :param custom: optional, custom data to attach to this node
+        :param ref: optional, reference that can be used to access this node
+        :return: this builder
+        """
+        if rotation is not None:
+            if len(rotation) != 9:
+                raise ValueError(f"Parameter `rotation` must have length 9")
+            if not self._is_rotation_matrix(rotation):
+                raise ValueError(f"Parameter `rotation` must be a rotation matrix")
+        if translation is not None:
+            if len(translation) != 3:
+                raise ValueError(f"Parameter `translation` must have length 3")
+        if matrix is not None:
+            if len(matrix) != 16:
+                raise ValueError(f"Parameter `matrix` must have length 16")
+            if rotation is not None or translation is not None:
+                raise ValueError("Parameter `matrix` cannot be used together with `rotation` or `translation`")
+
+        params = make_params(TransformParams, locals())
+        node = Node(kind="transform", params=params)
+        self._add_child(node)
+        return self
+
+    def instance(
+        self,
+        *,
+        rotation: Sequence[float] | None = None,
+        translation: Sequence[float] | None = None,
+        matrix: Sequence[float] | None = None,
+        custom: CustomT = None,
+        ref: RefT = None,
+    ) -> Self:
+        """
+        Instantiate the object by applying a rotation matrix and/or translation vector OR a full transform matrix.
+        :param rotation: 9d vector describing the rotation, in column major (j * 3 + i indexing) format, this is equivalent to Fortran-order in numpy, to be multiplied from the left (default: identity matrix)
+        :param translation: 3d vector describing the translation (default: (0, 0, 0))
+        :param matrix: 16d (4x4) vector describing the transformation matrix, in column major (j * 4 + i indexing) format, this is equivalent to Fortran-order in numpy, to be multiplied from the left. Takes precedence over `rotation` and `translation`.
+        :param custom: optional, custom data to attach to this node
+        :param ref: optional, reference that can be used to access this node
+        :return: this builder
+        """
+        if rotation is not None:
+            if len(rotation) != 9:
+                raise ValueError(f"Parameter `rotation` must have length 9")
+            if not self._is_rotation_matrix(rotation):
+                raise ValueError(f"Parameter `rotation` must be a rotation matrix")
+        if translation is not None:
+            if len(translation) != 3:
+                raise ValueError(f"Parameter `translation` must have length 3")
+        if matrix is not None:
+            if len(matrix) != 16:
+                raise ValueError(f"Parameter `matrix` must have length 16")
+            if rotation is not None or translation is not None:
+                raise ValueError("Parameter `matrix` cannot be used together with `rotation` or `translation`")
+
+        params = make_params(TransformParams, locals())
+        node = Node(kind="instance", params=params)
+        self._add_child(node)
+        return self
+
+    @staticmethod
+    def _is_rotation_matrix(t: Sequence[float], eps: float = 0.005):
+        a00, a01, a02, a10, a11, a12, a20, a21, a22 = t[0], t[1], t[2], t[3], t[4], t[5], t[6], t[7], t[8]
+
+        det3x3 = math.fabs(
+            a00 * (a11 * a22 - a12 * a21) - a01 * (a10 * a22 - a12 * a20) + a02 * (a10 * a21 - a11 * a20)
+        )
+        return math.isclose(det3x3, 1, abs_tol=eps)
+
+
 class _ClipMixin(_BuilderProtocol):
     @overload
     def clip(
@@ -628,7 +713,7 @@ class Parse(_Base):
         return Volume(node=node, root=self._root)
 
 
-class Structure(_Base, _PrimitivesMixin):
+class Structure(_Base, _PrimitivesMixin, _TransformMixin):
     """
     Builder step with operations needed after defining the structure to work with.
     """
@@ -846,47 +931,8 @@ class Structure(_Base, _PrimitivesMixin):
         self._add_child(node)
         return self
 
-    def transform(
-        self,
-        *,
-        rotation: Sequence[float] | None = None,
-        translation: Sequence[float] | None = None,
-        custom: CustomT = None,
-        ref: RefT = None,
-    ) -> Structure:
-        """
-        Transform a structure by applying a rotation matrix and/or translation vector.
-        :param rotation: 9d vector describing the rotation, in column major (j * 3 + i indexing) format, this is equivalent to Fortran-order in numpy, to be multiplied from the left (default: identity matrix)
-        :param translation: 3d vector describing the translation (default: (0, 0, 0))
-        :param custom: optional, custom data to attach to this node
-        :param ref: optional, reference that can be used to access this node
-        :return: this builder
-        """
-        if rotation is not None:
-            if len(rotation) != 9:
-                raise ValueError(f"Parameter `rotation` must have length 9")
-            if not self._is_rotation_matrix(rotation):
-                raise ValueError(f"Parameter `rotation` must be a rotation matrix")
-        if translation is not None:
-            if len(translation) != 3:
-                raise ValueError(f"Parameter `translation` must have length 3")
 
-        params = make_params(TransformParams, locals())
-        node = Node(kind="transform", params=params)
-        self._add_child(node)
-        return self
-
-    @staticmethod
-    def _is_rotation_matrix(t: Sequence[float], eps: float = 0.005):
-        a00, a01, a02, a10, a11, a12, a20, a21, a22 = t[0], t[1], t[2], t[3], t[4], t[5], t[6], t[7], t[8]
-
-        det3x3 = math.fabs(
-            a00 * (a11 * a22 - a12 * a21) - a01 * (a10 * a22 - a12 * a20) + a02 * (a10 * a21 - a11 * a20)
-        )
-        return math.isclose(det3x3, 1, abs_tol=eps)
-
-
-class Component(_Base, _FocusMixin):
+class Component(_Base, _FocusMixin, _TransformMixin):
     """
     Builder step with operations relevant for a particular component.
     """
@@ -1176,7 +1222,7 @@ class Representation(_Base, _ClipMixin):
         return self
 
 
-class Volume(_Base, _FocusMixin):
+class Volume(_Base, _FocusMixin, _TransformMixin):
     @overload
     def representation(
         self,

--- a/molviewspec/molviewspec/nodes.py
+++ b/molviewspec/molviewspec/nodes.py
@@ -1344,6 +1344,18 @@ Positions of primitives can be defined by 3D vector, by providing a selection ex
 a list of expressions within a specific structure.
 """
 
+LabelAttachmentT = Literal[
+    "bottom-left",
+    "bottom-center",
+    "bottom-right",
+    "middle-left",
+    "middle-center",
+    "middle-right",
+    "top-left",
+    "top-center",
+    "top-right",
+]
+
 
 class PrimitivesParams(BaseModel):
     color: Optional[ColorT] = Field(None, description="Default color for primitives in this group")
@@ -1351,6 +1363,22 @@ class PrimitivesParams(BaseModel):
     tooltip: Optional[str] = Field(None, description="Default tooltip for primitives in this group")
     opacity: Optional[float] = Field(None, description="Opacity of primitive geometry in this group")
     label_opacity: Optional[float] = Field(None, description="Opacity of primitive labels in this group")
+    label_show_tether: Optional[bool] = Field(
+        None,
+        description="Whether to show a tether line between the label and the target. Defaults to false.",
+    )
+    label_tether_length: Optional[float] = Field(
+        None,
+        description="Length of the tether line between the label and the target. Defaults to 1 (Angstrom).",
+    )
+    label_attachment: Optional[LabelAttachmentT] = Field(
+        None,
+        description="How to attach the label to the target. Defaults to 'middle-center'.",
+    )
+    label_background_color: Optional[ColorT] = Field(
+        None,
+        description="Background color of the label. Defaults to none/transparent.",
+    )
     instances: Optional[list[Mat4[float]]] = Field(
         None,
         description="Instances of this primitive group defined as 4x4 column major (j * 4 + i indexing) transformation matrices",

--- a/molviewspec/molviewspec/nodes.py
+++ b/molviewspec/molviewspec/nodes.py
@@ -32,6 +32,7 @@ KindT = Literal[
     "component_from_uri",
     "download",
     "focus",
+    "instance",
     "label",
     "label_from_source",
     "label_from_uri",
@@ -1304,9 +1305,13 @@ class TransformParams(BaseModel):
 
     rotation: Optional[Mat3[float]] = Field(
         None,
-        description="9d vector describing the rotation, in a column major (j * 3 + i indexing) format, this is equivalent to Fortran-order in numpy, to be multiplied from the left",
+        description="9d (3x3) vector describing the rotation, in a column major (j * 3 + i indexing) format, this is equivalent to Fortran-order in numpy, to be multiplied from the left",
     )
     translation: Optional[Vec3[float]] = Field(None, description="3d vector describing the translation")
+    matrix: Optional[Mat4[float]] = Field(
+        None,
+        description="16d (4x4) vector describing the transformation matrix, in a column major (j * 4 + i indexing) format, this is equivalent to Fortran-order in numpy, to be multiplied from the left. Takes precedence over `rotation` and `translation`.",
+    )
 
 
 class CameraParams(BaseModel):

--- a/molviewspec/molviewspec/nodes.py
+++ b/molviewspec/molviewspec/nodes.py
@@ -1379,6 +1379,10 @@ class PrimitivesParams(BaseModel):
         None,
         description="Background color of the label. Defaults to none/transparent.",
     )
+    snapshot_key: Optional[str] = Field(
+        None,
+        description="Load snapshot with the provided key when interacting with this primitives group.",
+    )
     instances: Optional[list[Mat4[float]]] = Field(
         None,
         description="Instances of this primitive group defined as 4x4 column major (j * 4 + i indexing) transformation matrices",

--- a/molviewspec/molviewspec/nodes.py
+++ b/molviewspec/molviewspec/nodes.py
@@ -589,7 +589,7 @@ class ComponentExpression(BaseModel):
 
 
 RepresentationTypeT = Literal["ball_and_stick", "spacefill", "cartoon", "surface", "isosurface", "carbohydrate"]
-VolumeRepresentationTypeT = Literal["isosurface", "grid-slice"]
+VolumeRepresentationTypeT = Literal["isosurface", "grid_slice"]
 ColorNamesT = Literal[
     "aliceblue",
     "antiquewhite",
@@ -1026,10 +1026,10 @@ class VolumeIsoSurfaceParams(RepresentationParams):
 
 class VolumeGridSliceParams(RepresentationParams):
     """
-    Volume grid-slice representation.
+    Volume grid_slice representation.
     """
 
-    type: Literal["grid-slice"] = "grid-slice"
+    type: Literal["grid_slice"] = "grid_slice"
 
     dimension: Literal["x", "y", "z"] = Field(description="Dimension of the grid slice, i.e. 'x', 'y', or 'z'.")
     absolute_index: Optional[int] = Field(

--- a/molviewspec/molviewspec/nodes.py
+++ b/molviewspec/molviewspec/nodes.py
@@ -585,7 +585,7 @@ class ComponentExpression(BaseModel):
 
 
 RepresentationTypeT = Literal["ball_and_stick", "spacefill", "cartoon", "surface", "isosurface", "carbohydrate"]
-VolumeRepresentationTypeT = Literal["isosurface"]
+VolumeRepresentationTypeT = Literal["isosurface", "grid-slice"]
 ColorNamesT = Literal[
     "aliceblue",
     "antiquewhite",
@@ -1020,7 +1020,33 @@ class VolumeIsoSurfaceParams(RepresentationParams):
     show_faces: Optional[bool] = Field(None, description="Show mesh faces. Defaults to true.")
 
 
-VolumeRepresentationTypeParams = {get_model_fields(t)["type"].default: t for t in (VolumeIsoSurfaceParams,)}
+class VolumeGridSliceParams(RepresentationParams):
+    """
+    Volume grid-slice representation.
+    """
+
+    type: Literal["grid-slice"] = "grid-slice"
+
+    dimension: Literal["x", "y", "z"] = Field(description="Dimension of the grid slice, i.e. 'x', 'y', or 'z'.")
+    absolute_index: Optional[int] = Field(
+        None,
+        description="Index of the grid slice in the specified dimension. 0-based index, i.e. 0 is the first slice.",
+    )
+    relative_index: Optional[float] = Field(
+        None,
+        description="Relative index of the grid slice in the specified dimension. 0.0 is the first slice, 1.0 is the last slice. Overrides `absolute_index`.",
+    )
+    relative_isovalue: Optional[float] = Field(None, description="Relative isovalue")
+    absolute_isovalue: Optional[float] = Field(None, description="Absolute isovalue. Overrides `relative_isovalue`.")
+
+
+VolumeRepresentationTypeParams = {
+    get_model_fields(t)["type"].default: t
+    for t in (
+        VolumeIsoSurfaceParams,
+        VolumeGridSliceParams,
+    )
+}
 
 
 ClipTypeT = Literal["plane", "sphere", "box"]


### PR DESCRIPTION
<!-- Thank you for contributing to mol-view-spec -->

# Description

- [x] grid-slice volume representation
- [x] primitive label tethers and background
- [x] snapshot transition support when interacting with 3D primitives
- [x] transform/instancing support for structures, components, and volumes

## Actions

- [x] Added description of changes to the `[Unreleased]` section of `CHANGELOG.md`
- [x] When adding new features:
  - [x] Added example(s) to `app/api/examples.py`
  - [ ] Added Jupyter Notebook to `test-data/notebooks` with new features
  - [ ] Added MkDocs documentation in `docs`