### PR TITLE
gaussian surface support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to this project will be documented in this file, following t
 - Add `snapshot_key` to `PrimitivesParams` that enables navigating to a different snapshot on interaction
 - Add `matrix` field support to `TransformParams`
 - Add `instance` node type
+- Add `surface_type` (`molecular` / `gaussian`) to the surface representation
 - Support transforms and instancing on structures, components, and volumes
 
 ## [v1.6.0] - 2025-04-22

--- a/molviewspec/molviewspec/builder.py
+++ b/molviewspec/molviewspec/builder.py
@@ -65,6 +65,7 @@ from molviewspec.nodes import (
     SnapshotMetadata,
     State,
     StructureParams,
+    SurfaceTypeT,
     TooltipFromSourceParams,
     TooltipFromUriParams,
     TooltipInlineParams,
@@ -1024,6 +1025,7 @@ class Component(_Base, _FocusMixin, _TransformMixin):
         self,
         *,
         type: Literal["surface"],
+        surface_type: SurfaceTypeT | None = None,
         ignore_hydrogens: bool | None = None,
         size_factor: float | None = None,
         custom: CustomT = None,
@@ -1032,6 +1034,7 @@ class Component(_Base, _FocusMixin, _TransformMixin):
         """
         Add a surface representation for this component.
         :param type: the type of this representation ('surface')
+        :param surface_type: the specific surface type to use (default is 'molecular')
         :param ignore_hydrogens: draw hydrogen atoms?
         :param size_factor: adjust the scale of the visuals (relative to 1.0)
         :param custom: optional, custom data to attach to this node

--- a/molviewspec/molviewspec/nodes.py
+++ b/molviewspec/molviewspec/nodes.py
@@ -961,13 +961,13 @@ class CartoonParams(RepresentationParams):
 
 class BallAndStickParams(RepresentationParams):
     type: Literal["ball_and_stick"] = "ball_and_stick"
-    ignore_hydrogens: Optional[bool] = Field(None, descripton="Controls whether hydrogen atoms are drawn.")
+    ignore_hydrogens: Optional[bool] = Field(None, description="Controls whether hydrogen atoms are drawn.")
     size_factor: Optional[float] = Field(None, description="Scales the corresponding visuals.")
 
 
 class SpacefillParams(RepresentationParams):
     type: Literal["spacefill"] = "spacefill"
-    ignore_hydrogens: Optional[bool] = Field(None, descripton="Controls whether hydrogen atoms are drawn.")
+    ignore_hydrogens: Optional[bool] = Field(None, description="Controls whether hydrogen atoms are drawn.")
     size_factor: Optional[float] = Field(None, description="Scales the corresponding visuals.")
 
 
@@ -976,9 +976,16 @@ class CarbohydrateParams(RepresentationParams):
     size_factor: Optional[float] = Field(None, description="Scales the corresponding visuals.")
 
 
+SurfaceTypeT = Literal["molecular", "gaussian"]
+
+
 class SurfaceParams(RepresentationParams):
     type: Literal["surface"] = "surface"
-    ignore_hydrogens: Optional[bool] = Field(None, descripton="Controls whether hydrogen atoms are drawn.")
+    surface_type: SurfaceTypeT = Field(
+        "molecular",
+        description="Type of surface representation. (Default is 'molecular')",
+    )
+    ignore_hydrogens: Optional[bool] = Field(None, description="Controls whether hydrogen atoms are drawn.")
     size_factor: Optional[float] = Field(None, description="Scales the corresponding visuals.")
 
 


### PR DESCRIPTION
<!-- Thank you for contributing to mol-view-spec -->

# Description

- [x] Add `surface_type` (`molecular` / `gaussian`) to the surface representation

## Actions

- [x] Added description of changes to the `[Unreleased]` section of `CHANGELOG.md`
- [ ] When adding new features:
  - [ ] Added example(s) to `app/api/examples.py`
  - [ ] Added Jupyter Notebook to `test-data/notebooks` with new features
  - [ ] Added MkDocs documentation in `docs`