### PR TITLE
Add `backbone` and `line` representation types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to this project will be documented in this file, following t
 - Add `matrix` field support to `TransformParams`
 - Add `instance` node type
 - Add `surface_type` (`molecular` / `gaussian`) to the surface representation
+- Add `backbone` and `line` representation types
 - Add `transform.rotation_center` to support rotating objects around their centroids or defined points
 - Add `coordinates` node to support loading coords from separate files
 - Add support for additional file formats (`pdbqt`, `gro`, `xyz`, `mol`, `sdf`, `mol2`, `xtc`, `lammpstrj`)

--- a/molviewspec/molviewspec/builder.py
+++ b/molviewspec/molviewspec/builder.py
@@ -1038,7 +1038,6 @@ class Component(_Base, _FocusMixin, _TransformMixin):
         self,
         *,
         type: Literal["backbone"],
-        ignore_hydrogens: bool | None = None,
         size_factor: float | None = None,
         custom: CustomT = None,
         ref: RefT = None,
@@ -1046,7 +1045,6 @@ class Component(_Base, _FocusMixin, _TransformMixin):
         """
         Add a backbone representation for this component.
         :param type: the type of this representation ('backbone')
-        :param ignore_hydrogens: draw hydrogen atoms?
         :param size_factor: adjust the scale of the visuals (relative to 1.0)
         :param custom: optional, custom data to attach to this node
         :param ref: optional, reference that can be used to access this node

--- a/molviewspec/molviewspec/builder.py
+++ b/molviewspec/molviewspec/builder.py
@@ -1037,6 +1037,27 @@ class Component(_Base, _FocusMixin, _TransformMixin):
     def representation(
         self,
         *,
+        type: Literal["backbone"],
+        ignore_hydrogens: bool | None = None,
+        size_factor: float | None = None,
+        custom: CustomT = None,
+        ref: RefT = None,
+    ) -> Representation:
+        """
+        Add a backbone representation for this component.
+        :param type: the type of this representation ('backbone')
+        :param ignore_hydrogens: draw hydrogen atoms?
+        :param size_factor: adjust the scale of the visuals (relative to 1.0)
+        :param custom: optional, custom data to attach to this node
+        :param ref: optional, reference that can be used to access this node
+        :return: a builder that handles operations at representation level
+        """
+        ...
+
+    @overload
+    def representation(
+        self,
+        *,
         type: Literal["ball_and_stick"],
         ignore_hydrogens: bool | None = None,
         size_factor: float | None = None,
@@ -1046,6 +1067,27 @@ class Component(_Base, _FocusMixin, _TransformMixin):
         """
         Add a ball-and-stick representation for this component.
         :param type: the type of this representation ('ball_and_stick')
+        :param ignore_hydrogens: draw hydrogen atoms?
+        :param size_factor: adjust the scale of the visuals (relative to 1.0)
+        :param custom: optional, custom data to attach to this node
+        :param ref: optional, reference that can be used to access this node
+        :return: a builder that handles operations at representation level
+        """
+        ...
+
+    @overload
+    def representation(
+        self,
+        *,
+        type: Literal["line"],
+        ignore_hydrogens: bool | None = None,
+        size_factor: float | None = None,
+        custom: CustomT = None,
+        ref: RefT = None,
+    ) -> Representation:
+        """
+        Add a line representation for this component.
+        :param type: the type of this representation ('line')
         :param ignore_hydrogens: draw hydrogen atoms?
         :param size_factor: adjust the scale of the visuals (relative to 1.0)
         :param custom: optional, custom data to attach to this node

--- a/molviewspec/molviewspec/nodes.py
+++ b/molviewspec/molviewspec/nodes.py
@@ -996,7 +996,6 @@ class CartoonParams(RepresentationParams):
 
 class BackboneParams(RepresentationParams):
     type: Literal["backbone"] = "backbone"
-    ignore_hydrogens: Optional[bool] = Field(None, description="Controls whether hydrogen atoms are drawn.")
     size_factor: Optional[float] = Field(None, description="Scales the corresponding visuals.")
 
 

--- a/molviewspec/molviewspec/nodes.py
+++ b/molviewspec/molviewspec/nodes.py
@@ -994,8 +994,20 @@ class CartoonParams(RepresentationParams):
     # TODO support for variable size, e.g. based on b-factors?
 
 
+class BackboneParams(RepresentationParams):
+    type: Literal["backbone"] = "backbone"
+    ignore_hydrogens: Optional[bool] = Field(None, description="Controls whether hydrogen atoms are drawn.")
+    size_factor: Optional[float] = Field(None, description="Scales the corresponding visuals.")
+
+
 class BallAndStickParams(RepresentationParams):
     type: Literal["ball_and_stick"] = "ball_and_stick"
+    ignore_hydrogens: Optional[bool] = Field(None, description="Controls whether hydrogen atoms are drawn.")
+    size_factor: Optional[float] = Field(None, description="Scales the corresponding visuals.")
+
+
+class LineRepresenatationParams(RepresentationParams):
+    type: Literal["line"] = "line"
     ignore_hydrogens: Optional[bool] = Field(None, description="Controls whether hydrogen atoms are drawn.")
     size_factor: Optional[float] = Field(None, description="Scales the corresponding visuals.")
 
@@ -1026,7 +1038,15 @@ class SurfaceParams(RepresentationParams):
 
 RepresentationTypeParams = {
     get_model_fields(cast(Type[RepresentationParams], t))["type"].default: t
-    for t in (CartoonParams, BallAndStickParams, SpacefillParams, CarbohydrateParams, SurfaceParams)
+    for t in (
+        CartoonParams,
+        BackboneParams,
+        BallAndStickParams,
+        LineRepresenatationParams,
+        SpacefillParams,
+        CarbohydrateParams,
+        SurfaceParams,
+    )
 }
 
 


### PR DESCRIPTION
<!-- Thank you for contributing to mol-view-spec -->

# Description

- [x] Add `backbone` and `line` representation types

## Actions

- [x] Added description of changes to the `[Unreleased]` section of `CHANGELOG.md`
- [ ] When adding new features:
  - [ ] Added example(s) to `app/api/examples.py`
  - [ ] Added Jupyter Notebook to `test-data/notebooks` with new features
  - [ ] Added MkDocs documentation in `docs`