### PR TITLE
feat: add mvs-putty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file, following t
 ## [Unreleased]
 
 - add molviewspec-ts, a typescript implementation of mol-view-spec
+- Add `putty` representation type with `size_theme` parameter (`"uniform"` for constant radius scaled by `size_factor`, `"uncertainty"` for B-factor/RMSF-driven radius)
 - `color_from_uri` and `color_from_source` take `selector` parameter
 - `label_from_*` and `tooltip_from_*` take `text_format` parameter
 - `label_from_*` take `group_by_fields` parameter

--- a/docs/docs/tree-schema.md
+++ b/docs/docs/tree-schema.md
@@ -298,7 +298,7 @@ Parent: `component` or `component_from_uri` or `component_from_source`
 
 Params:
 
-- **`type: `**`cartoon | backbone | ball_and_stick | line | spacefill | carbohydrate | surface`
+- **`type: `**`cartoon | backbone | ball_and_stick | line | spacefill | carbohydrate | surface | putty`
 
   Representation type
 
@@ -375,6 +375,22 @@ Params:
     Scales the corresponding visuals.
 
     Default: `1`
+
+  **Case `type: "putty"`:**
+
+  - **`size_factor?: `**`number`
+
+    Scales the corresponding visuals.
+
+    Default: `1`
+
+  - **`size_theme?: `**`"uniform" | "uncertainty"`
+
+    Controls how the tube radius is determined.
+    `"uniform"` uses a constant radius scaled by `size_factor`.
+    `"uncertainty"` drives the radius from per-residue B-factor/RMSF values.
+
+    Default: `"uniform"`
 
   **Case `type: "surface"`:**
 

--- a/molviewspec-ts/molviewspec/builder.ts
+++ b/molviewspec-ts/molviewspec/builder.ts
@@ -60,6 +60,7 @@ import type {
   PrimitiveLabelParams,
   PrimitivesFromUriParams,
   PrimitivesParams,
+  PuttyParams,
   RepresentationParams,
   Snapshot,
   SnapshotMetadata,
@@ -1109,6 +1110,23 @@ export class Component extends Base {
    *   type: "ball_and_stick",
    *   alpha: 0.8,
    *   size_factor: 1.5
+   * })
+   * ```
+   *
+   * @example Putty with constant (uniform) tube radius
+   * ```typescript
+   * component.representation({
+   *   type: "putty",
+   *   size_theme: "uniform",
+   *   size_factor: 0.5
+   * })
+   * ```
+   *
+   * @example Putty with B-factor/RMSF-driven tube radius
+   * ```typescript
+   * component.representation({
+   *   type: "putty",
+   *   size_theme: "uncertainty"
    * })
    * ```
    *

--- a/molviewspec-ts/molviewspec/nodes.ts
+++ b/molviewspec-ts/molviewspec/nodes.ts
@@ -24,6 +24,7 @@ import type {
   SchemaT,
   StateTreeT,
   StructureTypeT,
+  PuttySizeThemeT,
   SurfaceTypeT,
   Vec3,
   VolumeRepresentationTypeT,
@@ -283,6 +284,17 @@ export interface SpacefillParams {
  * Carbohydrate parameters.
  */
 export interface CarbohydrateParams {
+  [key: string]: unknown;
+}
+
+/**
+ * Putty parameters.
+ * The tube radius can be driven by a constant size_factor ("uniform") or
+ * per-residue B-factor/RMSF values ("uncertainty").
+ */
+export interface PuttyParams {
+  size_factor?: number;
+  size_theme?: PuttySizeThemeT;
   [key: string]: unknown;
 }
 
@@ -763,6 +775,7 @@ export type NodeParams =
   | LineRepresentationParams
   | SpacefillParams
   | CarbohydrateParams
+  | PuttyParams
   | SurfaceParams
   | VolumeRepresentationParams
   | VolumeIsoSurfaceParams

--- a/molviewspec-ts/molviewspec/types.ts
+++ b/molviewspec-ts/molviewspec/types.ts
@@ -123,7 +123,15 @@ export type RepresentationTypeT =
   | "isosurface"
   | "carbohydrate"
   | "backbone"
-  | "line";
+  | "line"
+  | "putty";
+
+/**
+ * Size theme for putty representation.
+ * - "uniform": constant tube radius, scaled by size_factor (default)
+ * - "uncertainty": per-residue radius driven by B-factor/RMSF values
+ */
+export type PuttySizeThemeT = "uniform" | "uncertainty";
 
 export type VolumeRepresentationTypeT = "isosurface" | "grid_slice";
 

--- a/molviewspec-ts/tests/serialization_test.ts
+++ b/molviewspec-ts/tests/serialization_test.ts
@@ -205,6 +205,105 @@ Deno.test("serialization - multi-state snapshots", () => {
   assertEquals(states.snapshots[1].metadata.transition_duration_ms, 500);
 });
 
+Deno.test("serialization - putty representation default", () => {
+  const builder = createBuilder();
+  builder
+    .download({ url: "https://files.wwpdb.org/download/1cbs.cif" })
+    .parse({ format: "mmcif" })
+    .modelStructure()
+    .component({ selector: "polymer" })
+    .representation({ type: "putty" });
+
+  const state = builder.getState();
+  const stateJson = JSON.stringify(state);
+
+  assertEquals(stateJson.includes("putty"), true);
+  assertEquals(stateJson.includes("representation"), true);
+});
+
+Deno.test("serialization - putty representation uniform size theme", () => {
+  const builder = createBuilder();
+  builder
+    .download({ url: "https://files.wwpdb.org/download/1cbs.cif" })
+    .parse({ format: "mmcif" })
+    .modelStructure()
+    .component({ selector: "polymer" })
+    .representation({ type: "putty", size_theme: "uniform", size_factor: 0.5 });
+
+  const state = builder.getState();
+  const stateJson = JSON.stringify(state);
+
+  assertEquals(stateJson.includes("putty"), true);
+  assertEquals(stateJson.includes("uniform"), true);
+  assertEquals(stateJson.includes("0.5"), true);
+});
+
+Deno.test("serialization - putty representation uncertainty size theme", () => {
+  const builder = createBuilder();
+  builder
+    .download({ url: "https://files.wwpdb.org/download/1cbs.cif" })
+    .parse({ format: "mmcif" })
+    .modelStructure()
+    .component({ selector: "polymer" })
+    .representation({ type: "putty", size_theme: "uncertainty" });
+
+  const state = builder.getState();
+  const stateJson = JSON.stringify(state);
+
+  assertEquals(stateJson.includes("putty"), true);
+  assertEquals(stateJson.includes("uncertainty"), true);
+});
+
+Deno.test("serialization - putty uncertainty with size_factor", () => {
+  const builder = createBuilder();
+  builder
+    .download({ url: "https://files.wwpdb.org/download/1cbs.cif" })
+    .parse({ format: "mmcif" })
+    .modelStructure()
+    .component({ selector: "polymer" })
+    .representation({
+      type: "putty",
+      size_theme: "uncertainty",
+      size_factor: 2.0,
+    });
+
+  const state = builder.getState();
+  const stateJson = JSON.stringify(state);
+
+  assertEquals(stateJson.includes("putty"), true);
+  assertEquals(stateJson.includes("uncertainty"), true);
+  assertEquals(stateJson.includes("2"), true);
+});
+
+Deno.test("serialization - putty node structure", () => {
+  const builder = createBuilder();
+  builder
+    .download({ url: "https://files.wwpdb.org/download/1cbs.cif" })
+    .parse({ format: "mmcif" })
+    .modelStructure()
+    .component({ selector: "polymer" })
+    .representation({ type: "putty", size_theme: "uniform", size_factor: 1.5 });
+
+  const state = builder.getState();
+
+  // Walk to the representation node
+  assertExists(state.root.children);
+  const download = state.root.children[0];
+  assertExists(download.children);
+  const parse = download.children[0];
+  assertExists(parse.children);
+  const structure = parse.children[0];
+  assertExists(structure.children);
+  const component = structure.children[0];
+  assertExists(component.children);
+  const representation = component.children[0];
+
+  assertEquals(representation.kind, "representation");
+  assertEquals((representation.params as any)?.type, "putty");
+  assertEquals((representation.params as any)?.size_theme, "uniform");
+  assertEquals((representation.params as any)?.size_factor, 1.5);
+});
+
 Deno.test("serialization - canvas and camera", () => {
   const builder = createBuilder();
   builder.canvas({ background_color: "#ffffff" });

--- a/molviewspec/app/api/examples.py
+++ b/molviewspec/app/api/examples.py
@@ -558,8 +558,10 @@ async def refs_example() -> MVSResponse:
 @router.get("/repr-params")
 async def repr_params_example() -> MVSResponse:
     """
-    Individual representations (cartoon, ball-and-stick, surface) can be further customized. The corresponding builder
-    function exposes additional method arguments depending on the chosen representation type.
+    Individual representations (cartoon, ball-and-stick, surface, putty) can be further customized. The corresponding
+    builder function exposes additional method arguments depending on the chosen representation type.
+    Putty supports two size themes: 'uniform' (constant radius scaled by size_factor) and
+    'uncertainty' (per-residue radius driven by B-factor/RMSF values).
     """
     builder = create_builder()
     component = (
@@ -567,6 +569,8 @@ async def repr_params_example() -> MVSResponse:
     )
     component.representation(type="cartoon", size_factor=1.5, tubular_helices=True)
     component.representation(type="surface", ignore_hydrogens=True).opacity(opacity=0.8)
+    component.representation(type="putty", size_theme="uniform", size_factor=0.5)
+    component.representation(type="putty", size_theme="uncertainty")
     return JSONResponse(builder.get_state().to_dict())
 
 
@@ -2950,14 +2954,14 @@ async def portfolio_modres() -> MVSResponse:
 async def portfolio_bfactor() -> MVSResponse:
     """
     Entry structure colored by B-factor, as created by PDBImages.
-    (We are missing putty representation and size theme!)
+    Uses putty representation with size_theme='uncertainty' so the tube radius also encodes B-factor/RMSF.
     """
     ID = "1tqn"
     builder = create_builder()
     structure_url = _url_for_mmcif(ID)
     annotation_url = f"http://0.0.0.0:9000/api/v1/examples/data/file/{ID}/bfactor.cif"
     struct = builder.download(url=structure_url).parse(format="mmcif").model_structure()
-    struct.component(selector="polymer").representation(type="cartoon").color_from_uri(
+    struct.component(selector="polymer").representation(type="putty", size_theme="uncertainty").color_from_uri(
         uri=annotation_url, format="cif", schema="all_atomic", category_name=f"bfactor"
     )
     struct.component(selector="ligand").representation(type="ball_and_stick").color_from_uri(
@@ -3068,7 +3072,6 @@ async def portfolio_pdbekb_segment_superpose(
 ) -> MVSResponse:
     """
     "PDBe-KB segment superpose view" from https://docs.google.com/spreadsheets/d/1sUSWmBLfKMmPLW2yqVnxWQTQoVk6SmQppdCfItyO1m0/edit#gid=0
-    (We are missing putty representation!)
     """
     builder = create_builder()
     structure_url1 = _url_for_mmcif(id1)  # TODO use model server, only retrieve the chain
@@ -3102,7 +3105,7 @@ async def portfolio_pdbekb_segment_superpose(
         )
         .component(selector=ComponentExpression(label_asym_id=chain2))
         .tooltip(text=f"{id2}, chain {chain2}")
-        .representation(type="cartoon")  # should be putty
+        .representation(type="putty", size_theme="uniform")
         .color(color="#cc5a03")
     )
     builder.canvas(background_color="#ffffff")
@@ -3113,7 +3116,6 @@ async def portfolio_pdbekb_segment_superpose(
 async def portfolio_pdbekb_ligand_superpose(chains: str = "1tqn:A,2nnj:A") -> MVSResponse:
     """
     "PDBe-KB ligand superpose view" from https://docs.google.com/spreadsheets/d/1sUSWmBLfKMmPLW2yqVnxWQTQoVk6SmQppdCfItyO1m0/edit#gid=0
-    (We are missing putty representation!)
     """
     builder = create_builder()
     for i, id_chain in enumerate(chains.split(",")):
@@ -3141,9 +3143,9 @@ async def portfolio_pdbekb_ligand_superpose(chains: str = "1tqn:A,2nnj:A") -> MV
                 ),
             )
         if i == 0:
-            struct.component(selector=ComponentExpression(label_asym_id=chain)).representation(type="cartoon").color(
-                color="#1d9873"
-            )  # should be putty
+            struct.component(selector=ComponentExpression(label_asym_id=chain)).representation(
+                type="putty", size_theme="uniform"
+            ).color(color="#1d9873")
         struct.component(selector="ligand").representation(type="ball_and_stick").color(color="#f602f7")
         struct.component(selector="ion").representation(type="ball_and_stick").color(color="#f602f7")
     builder.canvas(background_color="#ffffff")

--- a/molviewspec/molviewspec/builder.py
+++ b/molviewspec/molviewspec/builder.py
@@ -65,6 +65,8 @@ from molviewspec.nodes import (
     PrimitivesFromUriParams,
     PrimitivesParams,
     RefT,
+    PuttyParams,
+    PuttySizeThemeT,
     RepresentationTypeParams,
     RepresentationTypeT,
     SchemaFormatT,
@@ -1140,6 +1142,29 @@ class Component(_Base, _FocusMixin, _TransformMixin):
         Add a carbohydrate representation for this component.
         :param type: the type of this representation ('carbohydrate')
         :param size_factor: adjust the scale of the visuals (relative to 1.0)
+        :param custom: optional, custom data to attach to this node
+        :param ref: optional, reference that can be used to access this node
+        :return: a builder that handles operations at representation level
+        """
+        ...
+
+    @overload
+    def representation(
+        self,
+        *,
+        type: Literal["putty"],
+        size_factor: float | None = None,
+        size_theme: PuttySizeThemeT | None = None,
+        custom: CustomT = None,
+        ref: RefT = None,
+    ) -> Representation:
+        """
+        Add a putty representation for this component.
+        :param type: the type of this representation ('putty')
+        :param size_factor: adjust the scale of the visuals (relative to 1.0)
+        :param size_theme: controls how the tube radius is determined.
+            'uniform' uses a constant radius scaled by size_factor (default).
+            'uncertainty' drives the radius from per-residue B-factor/RMSF values.
         :param custom: optional, custom data to attach to this node
         :param ref: optional, reference that can be used to access this node
         :return: a builder that handles operations at representation level

--- a/molviewspec/molviewspec/nodes.py
+++ b/molviewspec/molviewspec/nodes.py
@@ -650,7 +650,7 @@ class ComponentExpression(BaseModel):
     )
 
 
-RepresentationTypeT = Literal["ball_and_stick", "spacefill", "cartoon", "surface", "isosurface", "carbohydrate"]
+RepresentationTypeT = Literal["ball_and_stick", "spacefill", "cartoon", "surface", "isosurface", "carbohydrate", "putty"]
 VolumeRepresentationTypeT = Literal["isosurface", "grid_slice"]
 ColorNamesT = Literal[
     "aliceblue",
@@ -1048,6 +1048,23 @@ class CarbohydrateParams(RepresentationParams):
     size_factor: Optional[float] = Field(None, description="Scales the corresponding visuals.")
 
 
+PuttySizeThemeT = Literal["uniform", "uncertainty"]
+
+
+class PuttyParams(RepresentationParams):
+    type: Literal["putty"] = "putty"
+    size_factor: Optional[float] = Field(None, description="Scales the corresponding visuals.")
+    size_theme: Optional[PuttySizeThemeT] = Field(
+        None,
+        description=(
+            "Controls how the tube radius is determined. "
+            "'uniform' uses a constant radius scaled by size_factor. "
+            "'uncertainty' drives the radius from per-residue B-factor/RMSF values. "
+            "Default: 'uniform'."
+        ),
+    )
+
+
 SurfaceTypeT = Literal["molecular", "gaussian"]
 
 
@@ -1070,6 +1087,7 @@ RepresentationTypeParams = {
         LineRepresenatationParams,
         SpacefillParams,
         CarbohydrateParams,
+        PuttyParams,
         SurfaceParams,
     )
 }

--- a/molviewspec/tests/test_serialization.py
+++ b/molviewspec/tests/test_serialization.py
@@ -4,7 +4,7 @@ import logging
 import unittest
 
 from molviewspec.builder import create_builder
-from molviewspec.molviewspec.nodes import MVSJ
+from molviewspec.nodes import MVSJ
 
 # Set up logging for tests
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s")
@@ -26,6 +26,92 @@ class TestSerialization(unittest.TestCase):
 
         self.assertIn("primitives", state)
         self.assertIn("box", state)
+
+    def test_putty_representation_default(self):
+        """Test that putty representation with no size_theme serializes correctly."""
+        builder = create_builder()
+        (
+            builder.download(url="https://files.wwpdb.org/download/1cbs.cif")
+            .parse(format="mmcif")
+            .model_structure()
+            .component(selector="polymer")
+            .representation(type="putty")
+        )
+        state = MVSJ(data=builder.get_state()).dumps()
+
+        self.assertIn("putty", state)
+        self.assertIn("representation", state)
+
+    def test_putty_representation_uniform(self):
+        """Test that putty with size_theme='uniform' serializes size_theme and size_factor correctly."""
+        builder = create_builder()
+        (
+            builder.download(url="https://files.wwpdb.org/download/1cbs.cif")
+            .parse(format="mmcif")
+            .model_structure()
+            .component(selector="polymer")
+            .representation(type="putty", size_theme="uniform", size_factor=0.5)
+        )
+        state = MVSJ(data=builder.get_state()).dumps()
+
+        self.assertIn("putty", state)
+        self.assertIn("uniform", state)
+        self.assertIn("0.5", state)
+
+    def test_putty_representation_uncertainty(self):
+        """Test that putty with size_theme='uncertainty' serializes size_theme correctly."""
+        builder = create_builder()
+        (
+            builder.download(url="https://files.wwpdb.org/download/1cbs.cif")
+            .parse(format="mmcif")
+            .model_structure()
+            .component(selector="polymer")
+            .representation(type="putty", size_theme="uncertainty")
+        )
+        state = MVSJ(data=builder.get_state()).dumps()
+
+        self.assertIn("putty", state)
+        self.assertIn("uncertainty", state)
+
+    def test_putty_representation_uncertainty_with_size_factor(self):
+        """Test that putty with size_theme='uncertainty' and a size_factor serializes both correctly."""
+        builder = create_builder()
+        (
+            builder.download(url="https://files.wwpdb.org/download/1cbs.cif")
+            .parse(format="mmcif")
+            .model_structure()
+            .component(selector="polymer")
+            .representation(type="putty", size_theme="uncertainty", size_factor=2.0)
+        )
+        state = MVSJ(data=builder.get_state()).dumps()
+
+        self.assertIn("putty", state)
+        self.assertIn("uncertainty", state)
+        self.assertIn("2.0", state)
+
+    def test_putty_representation_node_structure(self):
+        """Test that the putty representation node has the expected structure in the state tree."""
+        builder = create_builder()
+        (
+            builder.download(url="https://files.wwpdb.org/download/1cbs.cif")
+            .parse(format="mmcif")
+            .model_structure()
+            .component(selector="polymer")
+            .representation(type="putty", size_theme="uniform", size_factor=1.5)
+        )
+        state = builder.get_state()
+
+        # Walk to the representation node
+        download = state.root.children[0]
+        parse = download.children[0]
+        structure = parse.children[0]
+        component = structure.children[0]
+        representation = component.children[0]
+
+        self.assertEqual(representation.kind, "representation")
+        self.assertEqual(representation.params["type"], "putty")
+        self.assertEqual(representation.params["size_theme"], "uniform")
+        self.assertEqual(representation.params["size_factor"], 1.5)
 
 
 if __name__ == "__main__":

--- a/test-data/notebooks-ts/01_kras_structure_visualization.ipynb
+++ b/test-data/notebooks-ts/01_kras_structure_visualization.ipynb
@@ -144,6 +144,61 @@
   },
   {
    "cell_type": "markdown",
+   "id": "0d6f2167-e599-48db-af5f-54fcdb2348e6",
+   "metadata": {},
+   "source": [
+    "## Putty Representation\n",
+    "\n",
+    "The `putty` representation displays polymers as a smooth tube. The tube radius can be driven in two ways:\n",
+    "- `size_theme: 'uniform'`: constant radius scaled by `size_factor` (like `cartoon`/`backbone`)\n",
+    "- `size_theme: 'uncertainty'`: per-residue radius driven by B-factor/RMSF values\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a0be4bc4-c6f2-43c2-9854-48517f709357",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "// Putty with a constant (uniform) tube radius\n",
+    "const builderPuttyUniform = createBuilder();\n",
+    "\n",
+    "builderPuttyUniform\n",
+    "  .download({ url: 'https://files.wwpdb.org/download/1cbs.cif' })\n",
+    "  .parse({ format: 'mmcif' })\n",
+    "  .modelStructure()\n",
+    "  .component({ selector: 'polymer' })\n",
+    "  .representation({ type: 'putty', size_theme: 'uniform', size_factor: 0.5 })\n",
+    "  .color({ color: 'teal' });\n",
+    "\n",
+    "await molstarNotebook(builderPuttyUniform.getState());"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f6b82557-71db-40d0-8485-0acf4b598ffe",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "// Putty with B-factor/RMSF-driven tube radius (size_theme: 'uncertainty')\n",
+    "// The tube is thicker at residues with high B-factors, thinner where the structure is well-ordered.\n",
+    "const builderPuttyUncertainty = createBuilder();\n",
+    "\n",
+    "builderPuttyUncertainty\n",
+    "  .download({ url: 'https://files.wwpdb.org/download/1cbs.cif' })\n",
+    "  .parse({ format: 'mmcif' })\n",
+    "  .modelStructure()\n",
+    "  .component({ selector: 'polymer' })\n",
+    "  .representation({ type: 'putty', size_theme: 'uncertainty' })\n",
+    "  .color({ color: 'purple' });\n",
+    "\n",
+    "await molstarNotebook(builderPuttyUncertainty.getState());"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "custom-structure",
    "metadata": {},
    "source": [

--- a/test-data/notebooks/01_kras_structure_visualization.ipynb
+++ b/test-data/notebooks/01_kras_structure_visualization.ipynb
@@ -186,6 +186,63 @@
   },
   {
    "cell_type": "markdown",
+   "id": "2bb690ef-5c99-492c-bb7c-b440ce456a38",
+   "metadata": {},
+   "source": [
+    "## Putty Representation\n",
+    "\n",
+    "The `putty` representation displays polymers as a smooth tube. The tube radius can be driven in two ways:\n",
+    "- `size_theme='uniform'`: constant radius scaled by `size_factor` (like `cartoon`/`backbone`)\n",
+    "- `size_theme='uncertainty'`: per-residue radius driven by B-factor/RMSF values\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ce6f6c68-9abd-47a7-855e-6e2e571b1622",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Putty with a constant (uniform) tube radius\n",
+    "builder = mvs.create_builder()\n",
+    "\n",
+    "structure = (\n",
+    "    builder.download(url='https://files.wwpdb.org/download/1cbs.cif')\n",
+    "    .parse(format='mmcif')\n",
+    "    .model_structure()\n",
+    ")\n",
+    "structure.component(selector='polymer').representation(\n",
+    "    type='putty', size_theme='uniform', size_factor=0.5\n",
+    ").color(color='teal')\n",
+    "\n",
+    "builder"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3e7fbab9-7ce2-4d31-bd7c-c0bf2c713c49",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Putty with B-factor/RMSF-driven tube radius (size_theme='uncertainty')\n",
+    "# The tube is thicker at residues with high B-factors, thinner where the structure is well-ordered.\n",
+    "builder = mvs.create_builder()\n",
+    "\n",
+    "structure = (\n",
+    "    builder.download(url='https://files.wwpdb.org/download/1cbs.cif')\n",
+    "    .parse(format='mmcif')\n",
+    "    .model_structure()\n",
+    ")\n",
+    "structure.component(selector='polymer').representation(\n",
+    "    type='putty', size_theme='uncertainty'\n",
+    ").color(color='purple')\n",
+    "\n",
+    "builder"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "e8452e85-0f2a-4811-98db-1475429561d7",
    "metadata": {},
    "source": [


### PR DESCRIPTION
# Description

Add `putty` implementation to the TS and Py MolViewSpec libraries

Followed the same  argument structure as other representations: 

| MVS type | Mol* `sizeTheme` used | What `size_factor` actually controls |
|---|---|---|
| `cartoon` | `uniform` | `value` = `size_factor` → constant tube radius |
| `backbone` | `uniform` | `value` = `size_factor` → constant tube radius |
| `ball_and_stick` | `uniform` | `value` = `size_factor` → constant atom/bond size |
| `line` | `uniform` | `value` = `size_factor` → constant line width |
| `spacefill` | `physical` | `scale` = `size_factor` → scales vdW radii |
| `carbohydrate` | `uniform` | `value` = `size_factor` → constant symbol size |
| `surface` (molecular) | `physical` | `scale` = `size_factor` → scales vdW-based surface |
| `surface` (gaussian) | `physical` | `scale` = `size_factor` → scales vdW-based surface |
| `putty` |  `uniform`  \| `uncertainty`  | `sizeFactor`  is either a constant scale or scales the — the per-residue B-factor .

Note:  The current MVS template implementations both use embedded Molstar within their output widgets and the current molstar MVS implementation doesn't  yet support `putty`.  We will want to hold off on this PR until [the Molstar implementation is in place](https://github.com/molstar/molstar/pull/1783) and we have a public release that supports `putty`.



## Actions

- [x] Added description of changes to the `[Unreleased]` section of `CHANGELOG.md`
- [x] When adding new features:
  - [x] Added example(s) to `app/api/examples.py`
  - [x] Added Jupyter Notebook to `test-data/notebooks` (python) and `test-data/notebooks-ts` (typescsript) with new features
  - [x] Added MkDocs documentation in `docs`
  - [x] When changing the API, make sure the change is coherent between the TS and Python versions (see molviewspec-ts/readme.md).
